### PR TITLE
Async initialisation

### DIFF
--- a/loader/repl.html
+++ b/loader/repl.html
@@ -182,7 +182,6 @@
                                             }
 
                                             (async () => {
-                                                let webR = await webRPromise;
                                                 try {
                                                     await webR.loadPackages(packages);
                                                     props.responseText = text;
@@ -251,36 +250,42 @@
             parents[0]='';
             return parents.join('/');
         },
-        downloadNodeasFile: function(node){
-            var filename = node.text;
-            var filepath = this.getNodeFileName(node);
-            webRPromise.then(webR => webR.getFileData(filepath)).then( data => {
-                var blob = new Blob([data], {type: "application/octet-stream"});
-                var url = URL.createObjectURL(blob);
-                const link = document.createElement('a');
-                link.download = filename;
-                link.href = url;
-                link.click();
-                link.delete;
-            });
+        downloadNodeasFile: async function(node) {
+            let filepath = this.getNodeFileName(node);
+            let data = await webR.getFileData(filepath);
+
+            let filename = node.text;
+            let blob = new Blob([data], { type: "application/octet-stream" });
+            let url = URL.createObjectURL(blob);
+
+            const link = document.createElement('a');
+            link.download = filename;
+            link.href = url;
+            link.click();
+            link.delete;
         },
-        uploadFile: function(fileInput){
-            var node = this.getSelectedNode();
-            var filepath = this.getNodeFileName(node);
+        uploadFile: function(fileInput) {
+            let node = this.getSelectedNode();
+            let filepath = this.getNodeFileName(node);
+
             if (filepath === ''){
                 filepath = '/';
             }
-            if (fileInput.files.length == 0)
+            if (fileInput.files.length == 0) {
                 return;
-            var file = fileInput.files[0];
-            var fr = new FileReader();
-            fr.onload = function () {
-                var data = new Uint8Array(fr.result);
-                webRPromise.then(webR => webR.putFileData(filepath + '/' + file.name, data)).then( function(){
-                    this.jstree.refresh()
-                }.bind(this));
+            }
+
+            let file = fileInput.files[0];
+            let fr = new FileReader();
+
+            let jstree = this.jstree;
+            fr.onload = async function () {
                 fileInput.value = '';
-            }.bind(this);
+                var data = new Uint8Array(fr.result);
+                await webR.putFileData(filepath + '/' + file.name, data);
+                jstree.refresh()
+            };
+
             fr.readAsArrayBuffer(file);
         },
         getNodeJSON: function(node){
@@ -312,7 +317,8 @@
             };
         },
     };
-    var webRPromise = loadWebR({
+
+    var webR = newWebr({
         Rargs: [],
         runtimeInitializedCB: function(){
             FSTree.init();
@@ -336,9 +342,12 @@
             term.error(text);
         },
     });
-    webRPromise.then(_ => {
+
+    (async () => {
+        await webR.init();
         FSTree.init();
-    })
+    })();
+
     const download = document.getElementById('download-file');
     download.addEventListener('click', function (e) {
         FSTree.downloadNodeasFile(FSTree.getSelectedNode());

--- a/loader/repl.html
+++ b/loader/repl.html
@@ -318,7 +318,7 @@
         },
     };
 
-    var webR = newWebr({
+    var webR = newWebR({
         Rargs: [],
         runtimeInitializedCB: function(){
             FSTree.init();

--- a/loader/repl.html
+++ b/loader/repl.html
@@ -316,7 +316,6 @@
         Rargs: [],
         runtimeInitializedCB: function(){
             FSTree.init();
-            term.clear();
         },
         loadingPackageCB: function(packageName){
             term.echo("Downloading webR package: " + packageName);
@@ -337,6 +336,9 @@
             term.error(text);
         },
     });
+    webRPromise.then(_ => {
+        FSTree.init();
+    })
     const download = document.getElementById('download-file');
     download.addEventListener('click', function (e) {
         FSTree.downloadNodeasFile(FSTree.getSelectedNode());

--- a/loader/webR.js
+++ b/loader/webR.js
@@ -1,4 +1,4 @@
-function loadWebR(options){
+function newWebr(options) {
     if(options.packages === undefined) options.packages = [];
     if(options.Rargs === undefined) options.Rargs = ['-q'];
     if(options.runtimeInitializedCB === undefined) options.runtimeInitializedCB = function(){};
@@ -52,6 +52,8 @@ function loadWebR(options){
             return(window.Module._run_R_from_JS(allocate(intArrayFromString(code), 0), code.length));
         },
         getFileData: async function(name){
+            await webR._initialised;
+
             var FS = window.FS;
             var size = FS.stat(name).size;
             var stream = FS.open(name, 'r');
@@ -89,7 +91,7 @@ function loadWebR(options){
         },
 
         _initialised: null,
-        _init: function() {
+        init: function() {
             webR._initialised = new Promise((resolve, _reject) => {
                 window.Module = {
                     preRun: [function() { ENV = options.ENV }],
@@ -136,7 +138,7 @@ function loadWebR(options){
         }
     }
 
-    return webR._init();
+    return webR;
 }
 
 async function loadScript(src) {

--- a/loader/webR.js
+++ b/loader/webR.js
@@ -1,4 +1,4 @@
-function newWebr(options) {
+function newWebR(options) {
     if(options.packages === undefined) options.packages = [];
     if(options.Rargs === undefined) options.Rargs = ['-q'];
     if(options.runtimeInitializedCB === undefined) options.runtimeInitializedCB = function(){};

--- a/loader/webR.js
+++ b/loader/webR.js
@@ -91,7 +91,7 @@ function newWebr(options) {
         },
 
         _initialised: null,
-        init: function() {
+        init: async function() {
             webR._initialised = new Promise((resolve, _reject) => {
                 window.Module = {
                     preRun: [function() { ENV = options.ENV }],
@@ -99,7 +99,7 @@ function newWebr(options) {
                     arguments: options.Rargs,
                     noExitRuntime: true,
                     locateFile: function(path, _prefix) {
-                        return( options.WEBR_URL + path);
+                        return(options.WEBR_URL + path);
                     },
                     print: function(text){
                         options.stdout(text);
@@ -130,11 +130,11 @@ function newWebr(options) {
                 return webR;
             });
 
-            return webR._initialised.then(_ => {
-                options.runtimeInitializedCB();
-                webR.loadPackages(options.packages);
-                return webR;
-            })
+            await webR._initialised;
+
+            options.runtimeInitializedCB();
+            webR.loadPackages(options.packages);
+            return webR;
         }
     }
 


### PR DESCRIPTION
Progress towards making `webR` a class suitable for Comlink.

- `loadWebR()` is now a refactored as a constructor that returns immediately.
- `webR.init()` is a public method that asynchronously load webR.
- The webR methods are async and guarded with an `await this.initialised` so that the callers don't have to worry about webR being initialised.