### PR TITLE
Add `rebuild-main` target

### DIFF
--- a/R/Makefile
+++ b/R/Makefile
@@ -171,8 +171,8 @@ install: $(BUILD)/state/r-stage2
 	cp -r "$(R_WASM)/dist/." $(DIST)
 
 
-.PHONY: rebuild-main
-rebuild-main:
+.PHONY: rebuild-core
+rebuild-core:
 	rm -f $(BUILD)/state/r-stage2
 	cd $(STAGE2_BUILD)/src/unix && \
 	  $(MAKE_WASM_BUILD)

--- a/R/Makefile
+++ b/R/Makefile
@@ -167,9 +167,17 @@ install: $(BUILD)/state/r-stage2
 	cd $(R_SOURCE)/build/doc && \
 	  touch NEWS NEWS.pdf NEWS.rds NEWS.2.rds NEWS.3.rds
 	cd $(R_SOURCE)/build && \
-	  $(MAKE_WASM_INSTALL) install-wasm; \
+	  $(MAKE_WASM_INSTALL) install-wasm
 	cp -r "$(R_WASM)/dist/." $(DIST)
 
+
+.PHONY: rebuild-main
+rebuild-main:
+	rm -f $(BUILD)/state/r-stage2
+	cd $(STAGE2_BUILD)/src/main && \
+	  $(MAKE_WASM_BUILD) R && \
+	  $(MAKE_WASM_INSTALL) install-wasm
+	cp -r "$(R_WASM)/dist/." $(DIST)
 
 .PHONY: XZ
 XZ: $(XZ_WASM_LIB)

--- a/R/Makefile
+++ b/R/Makefile
@@ -174,6 +174,8 @@ install: $(BUILD)/state/r-stage2
 .PHONY: rebuild-main
 rebuild-main:
 	rm -f $(BUILD)/state/r-stage2
+	cd $(STAGE2_BUILD)/src/unix && \
+	  $(MAKE_WASM_BUILD)
 	cd $(STAGE2_BUILD)/src/main && \
 	  $(MAKE_WASM_BUILD) R && \
 	  $(MAKE_WASM_INSTALL) install-wasm

--- a/patches/R-4.1.3/emscripten-makefiles.diff
+++ b/patches/R-4.1.3/emscripten-makefiles.diff
@@ -35,8 +35,8 @@ Index: R-4.1.3/src/main/Makefile.in
 +
 +install-wasm: $(R_bin_DEPENDENCIES)
 +	@$(MKINSTALLDIRS) "$(prefix)/dist"
-+	@mv "$(Rexeclibdir)/libRblas.so" "$(prefix)/dist/libRblas.so"
-+	@mv "$(Rexeclibdir)/libRlapack.so" "$(prefix)/dist/libRlapack.so"
++	@cp "$(Rexeclibdir)/libRblas.so" "$(prefix)/dist/libRblas.so"
++	@cp "$(Rexeclibdir)/libRlapack.so" "$(prefix)/dist/libRlapack.so"
 +	@$(MAKE) $(R_binary).js
 +
  libR.a: $(OBJECTS) $(STATIC_LIBS)


### PR DESCRIPTION
This new target quickly rebuilds any changed `.c` file in `src/main` and recreates the distributed wasm file. Helpful for quick iterative development.