### PR TITLE
Add `make serve` command with support for CORP and COEP headers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,8 @@
 WEBR_ROOT = $(abspath ..)
 DIST = $(WEBR_ROOT)/dist
 
+ROOT = $(abspath .)
+
 HTML_TEMPLATES = console.html repl.html
 ENTRY_POINTS = console/console.ts repl/repl.ts webR/webR.ts
 HTML_INDEX = repl.html
@@ -32,6 +34,10 @@ check:
 node_modules: package.json
 	npm ci
 	touch $@
+
+.PHONY: serve
+serve:
+	cd $(DIST) && $(ROOT)/serve.py
 
 clean:
 	rm -f webR/config.ts

--- a/src/serve.py
+++ b/src/serve.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+# This is a simple wrapper that sets the CORP and COEP headers which
+# are required for using SharedArrayBuffer across Web Workers
+
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+import sys
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    test(CORSRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)


### PR DESCRIPTION
Allows using SharedArrayBuffer in web workers.