### PR TITLE
Add support for local webr-repo configuration

### DIFF
--- a/R/Makefile
+++ b/R/Makefile
@@ -33,6 +33,8 @@ WASM_LIBS = $(PCRE_WASM_LIB) $(XZ_WASM_LIB) $(FORTRAN_WASM_LIB)
 
 # Configure your local environment in this file
 -include ~/.webr-config.mk
+export WEBR_REPO
+export WEBR_LIB
 
 WASM_OPT ?= -Oz
 WASM_OPT_LDADD ?= $(WASM_OPT)
@@ -144,6 +146,9 @@ $(BUILD)/state/r-stage2-configured: $(BUILD)/state/r-patched $(WASM_LIBS)
 	      --enable-byte-compiled-packages=no \
 	      --enable-static=yes \
 	      --host=wasm32-unknown-emscripten
+# Disable umask which doesn't work well within Emscripten. Fixes
+# permission issues when extracting tarballs.
+	sed -i "" "/#define HAVE_UMASK/d" $(R_SOURCE)/build/src/include/config.h
 	touch $@
 
 STAGE2_BUILD = $(R_SOURCE)/build

--- a/patches/R-4.1.3/emscripten-makefiles.diff
+++ b/patches/R-4.1.3/emscripten-makefiles.diff
@@ -19,10 +19,21 @@ Index: R-4.1.3/src/main/Makefile.in
 ===================================================================
 --- R-4.1.3.orig/src/main/Makefile.in
 +++ R-4.1.3/src/main/Makefile.in
-@@ -147,6 +147,24 @@ R: Makedeps
+@@ -147,6 +147,34 @@ R: Makedeps
  $(R_binary): $(R_bin_OBJECTS) $(R_bin_DEPENDENCIES)
  	$(MAIN_LINK) -o $@ $(R_bin_OBJECTS) $(R_bin_LDADD)
  
++MAIN_WEBR_LDADD  = --use-preload-plugins
++MAIN_WEBR_LDADD += --preload-file "$(prefix)/tmp/lib@/usr/lib"
++
++ifdef WEBR_REPO
++MAIN_WEBR_LDADD += --preload-file "$(WEBR_REPO)@/repo"
++endif
++
++ifdef WEBR_LIB
++MAIN_WEBR_LDADD += --preload-file "${WEBR_LIB}@/usr/lib/R/library"
++endif
++
 +$(R_binary).js: $(R_bin_OBJECTS) $(R_bin_DEPENDENCIES)
 +	@rm -rf "$(prefix)/tmp" && mkdir -p "$(prefix)/tmp"
 +	@cp -a "$(prefix)/lib" "$(prefix)/tmp/"
@@ -30,8 +41,7 @@ Index: R-4.1.3/src/main/Makefile.in
 +	@rm -r "$(prefix)/tmp/lib/R/bin"
 +	@rm -r "$(prefix)/tmp/lib/R/include"
 +	@rm -r "$(prefix)/tmp/lib/R/doc"
-+	$(MAIN_LINK) --use-preload-plugins \
-+	--preload-file "$(prefix)/tmp/lib@/usr/lib" \
++	$(MAIN_LINK) $(MAIN_WEBR_LDADD) \
 +	-o $(prefix)/dist/$(R_binary).js \
 +	$(R_bin_OBJECTS) -lRlapack $(FORTRAN_WASM_LDADD) $(R_bin_LDADD)
 +


### PR DESCRIPTION
The variables `WEBR_REPO` and `WEBR_LIB` can now be configured in `~/.webr-config.mk`. These should point to the `lib` and `repo` folders created with https://github.com/lionel-/webr-repo/. This is mainly for local dev and debugging.

- `WEBR_REPO` specifies a local CRAN-like repository. Then `webr_install()` from https://github.com/lionel-/webr-repo/blob/main/install.R can be used to install packages.

- `WEBR_LIB` specifies a local directory of built packages. These are automatically installed.

The PR also disables `HAVE_UMASK` to fix a permission error triggered within the internal `untar()` method called by `webr_install()`.