### PR TITLE
Fix fetching libs when loading cross-origin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ EMFC_FILES = $(EMFC) $(FORTRAN_WASM_LIB)
 webr: $(EMFC_FILES)
 	cd R && $(MAKE) && $(MAKE) install
 	cd src && $(MAKE)
+# Patch R.bin.js to workaround Emscripten issue #14502
+# https://github.com/emscripten-core/emscripten/issues/14502
+	sed -i '' "s|readAsync(libFile,|readAsync(locateFile(libFile),|" dist/R.bin.js
 
 $(EMFC_FILES):
 	cd $(EMFC_DIR) && $(MAKE) && $(MAKE) install


### PR DESCRIPTION
Patch R.bin.js to workaround Emscripten issue #14502
"locateFile not used when loading SIDE_MODULES"
https://github.com/emscripten-core/emscripten/issues/14502

TBH I'm not overly keen on this `sed`. I might look into submitting a patch to the Emscripten repo, but sbc100 has asked for any patch to include a test case so I'll need to work out how to create an Emscripten unit test and think of some way to actually test the issue is fixed.