### PR TITLE
WIP: Reimplement package loading via `webr_install` and a CRAN-like repo

### DIFF
--- a/src/webR/config.ts.in
+++ b/src/webR/config.ts.in
@@ -1,2 +1,2 @@
 export const BASE_URL = '@@BASE_URL@@';
-export const PKG_BASE_URL = 'https://cdn.jsdelivr.net/gh/georgestagg/webr-ports/dist/';
+export const PKG_BASE_URL = 'https://webr.gwstagg.co.uk/repo/';

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -26,6 +26,12 @@ export class WebR {
     this.write({ type: 'stdin', data: input });
   }
 
+  async installPackages(packages: string[]) {
+    for (const pkg of packages) {
+      const msg = { type: 'installPackage', data: { name: pkg } };
+      await this.#chan.request(msg);
+    }
+  }
   async putFileData(name: string, data: Uint8Array) {
     const msg = { type: 'putFileData', data: { name: name, data: data } };
     await this.#chan.request(msg);

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -76,6 +76,9 @@ function inputOrDispatch(chan: ChannelWorker): string {
           case 'getFSNode':
             write(getFSNode(reqMsg.data.path as string));
             continue;
+          case 'installPackage':
+            write(evalRCode(`webr_install("${reqMsg.data.name as string}")`));
+            continue;
           case 'getRObj': {
             const data = reqMsg.data as {
               target: RTargetObj;
@@ -205,7 +208,7 @@ function setRObj(root: RSexp, path: string[], value: RSexp) {
   }
 }
 
-function evalRCode(code: string, env: RTargetObj | undefined): RSexpPtr {
+function evalRCode(code: string, env?: RTargetObj | undefined): RSexpPtr {
   const str = Module.allocateUTF8(code);
   const err = Module.allocate(1, 'i32', 0);
 


### PR DESCRIPTION
Includes #39.

This PR re-implements package loading for the webR REPL. Rather than using georgestagg/webR-ports, this uses Lionel's CRAN-like repo idea (I've hosted a repo at `https://webr.gwstagg.co.uk/repo/` for the moment) and `webr_install`.

Here `webr_install` is injected into R at REPL startup by writing a preamble to the console at init, but in future this will be tidied up and made more stable as part of a `webR` R package distributed as part of the REPL app.

The webR REPL website is currently running this build, so libraries can now be loaded again in the demo.