### PR TITLE
Fix loading webR cross-domain

### DIFF
--- a/src/esbuild.js
+++ b/src/esbuild.js
@@ -1,7 +1,7 @@
 const esbuild = require('esbuild');
 const cssModulesPlugin = require('esbuild-css-modules-plugin');
 
-function build({ input, output, minify }) {
+function build({ input, output, platform, minify }) {
   esbuild.build({
     entryPoints: [`${input}`],
     bundle: true,
@@ -10,7 +10,9 @@ function build({ input, output, minify }) {
     sourcemap: true,
     outfile: `../dist/${output}`,
     logLevel: 'info',
-    platform: 'node',
+    platform: platform,
+    mainFields: ['main', 'module'],
+    external: ['worker_threads', 'path', 'fs'],
     assetNames: 'assets/[name]-[hash]',
     loader: {
       '.jpg': 'file',
@@ -29,16 +31,25 @@ function build({ input, output, minify }) {
   {
     input: "webR/webr-worker.ts",
     output: "../dist/webr-worker.js",
+    platform: 'node',
+    minify: false,
+  },
+  {
+    input: "webR/webr-main.ts",
+    output: "webr.mjs",
+    platform: 'neutral',
     minify: false,
   },
   {
     input: "repl/repl.ts",
-    output: "../dist/repl.js",
+    output: "../dist/repl.mjs",
+    platform: 'neutral',
     minify: true,
   },
   {
     input: "console/console.ts",
-    output: "../dist/console.js",
+    output: "../dist/console.mjs",
+    platform: 'neutral',
     minify: true,
   },
 ].map(build);

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -4,5 +4,5 @@
 </head>
 <body>
 </body>
-<script type="module" src="console.js"></script>
+<script type="module" src="console.mjs"></script>
 </html>

--- a/src/templates/repl.html
+++ b/src/templates/repl.html
@@ -129,5 +129,5 @@
         </div>
     </div>
 </body>
-<script type="module" src="repl.js"></script>
+<script type="module" src="repl.mjs"></script>
 </html>

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -43,6 +43,23 @@ export class ChannelMain {
     };
 
     if (url.startsWith('http')) {
+      /* Workaround for loading a cross-origin script.
+       *
+       * When fetching a worker script, the fetch is required by the spec to
+       * use "same-origin" mode. This is to avoid loading a worker with a
+       * cross-origin global scope, which can allow for a cross-origin
+       * restriction bypass.
+       *
+       * When the fetch URL begins with 'http', we assume the request is
+       * cross-origin. We download the content of the URL using a XHR first,
+       * create a blob URL containing the requested content, then load the
+       * blob URL as a script.
+       *
+       * The origin of a blob URL is the same as that of the environment that
+       * created the URL, and so the global scope of the resulting worker is
+       * no longer cross-origin. In that case, the cross-origin restriction
+       * bypass is not possible, and the script is permitted to be loaded.
+       */
       const req = new XMLHttpRequest();
       req.open('get', url, true);
       req.onload = () => {

--- a/src/webR/compat.ts
+++ b/src/webR/compat.ts
@@ -25,6 +25,23 @@ if (globalThis.document) {
   loadScript = async (url) => {
     try {
       if (url.startsWith('http')) {
+        /* Workaround for loading a cross-origin script.
+         *
+         * When fetching a worker script, the fetch is required by the spec to
+         * use "same-origin" mode. This is to avoid loading a worker with a
+         * cross-origin global scope, which can allow for a cross-origin
+         * restriction bypass.
+         *
+         * When the fetch URL begins with 'http', we assume the request is
+         * cross-origin. We download the content of the URL using a XHR first,
+         * create a blob URL containing the requested content, then load the
+         * blob URL as a script.
+         *
+         * The origin of a blob URL is the same as that of the environment that
+         * created the URL, and so the global scope of the resulting worker is
+         * no longer cross-origin. In that case, the cross-origin restriction
+         * bypass is not possible, and the script is permitted to be loaded.
+         */
         const req = new XMLHttpRequest();
         req.open('get', url, true);
         req.onload = function () {

--- a/src/webR/compat.ts
+++ b/src/webR/compat.ts
@@ -24,7 +24,16 @@ if (globalThis.document) {
 } else if (globalThis.importScripts) {
   loadScript = async (url) => {
     try {
-      globalThis.importScripts(url);
+      if (url.startsWith('http')) {
+        const req = new XMLHttpRequest();
+        req.open('get', url, true);
+        req.onload = function () {
+          globalThis.importScripts(URL.createObjectURL(new Blob([req.responseText])));
+        };
+        req.send();
+      } else {
+        globalThis.importScripts(url);
+      }
     } catch (e) {
       if (e instanceof TypeError) {
         await import(url);

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -1,5 +1,6 @@
 import { ChannelMain } from './chan/channel';
 import { Message } from './chan/message';
+import { BASE_URL } from './config';
 
 export type FSNode = {
   id: number;
@@ -21,7 +22,7 @@ export class WebR {
   #chan;
 
   constructor(options: WebROptions = {}) {
-    this.#chan = new ChannelMain('./webr-worker.js', options);
+    this.#chan = new ChannelMain(`${BASE_URL}webr-worker.js`, options);
   }
 
   async init() {


### PR DESCRIPTION
With this commit, the main webR class and the JS worker can be loaded into web pages on different origins.

The commit adds a workaround that replaces using `loadScripts(url)` and `Worker(url)` directly with fetching the file content with XHR first, creating a URL blob with the content, then loading that. That way, the content is allowed to run even when the webR files and the source content are loaded via different origins.

The workaround kicks in only if the configured `BASE_URL` begins with the string `http`. Otherwise it is assumed loading the URL directly is OK.

The commit also edits our esbuild config to build some of our outputs as "neutral" type `.mjs` files, rather than using the "node" platform for everything. The switch to neutral will be needed later for loading webR as a JS module into a page from a CDN URL. The switch to using the `.mjs` extension is not strictly required for the browser, but it is required when running in node with this platform format.

