### PR TITLE
eval_R_6: RProxy R objects on the main thread

### DIFF
--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -59,6 +59,7 @@ export interface Module extends EmscriptenModule {
   _Rf_lang1: (ptr1: RPtr) => RPtr;
   _Rf_lang2: (ptr1: RPtr, ptr2: RPtr) => RPtr;
   _Rf_lang3: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr) => RPtr;
+  _Rf_mkChar: (ptr: number) => RPtr;
   _Rf_mkString: (ptr: number) => RPtr;
   _Rf_protect: (ptr: RPtr) => RPtr;
   _Rf_unprotect: (n: number) => void;
@@ -71,6 +72,8 @@ export interface Module extends EmscriptenModule {
   _R_GlobalEnv: RPtr;
   _R_NilValue: RPtr;
   _R_UnboundValue: RPtr;
+  _SET_STRING_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;
+  _SET_VECTOR_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;
   // TODO: Namespace all webR properties
   webr: {
     readConsole: () => number;

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -1,0 +1,84 @@
+import { RTargetObj, RTargetPtr, RObj, RTargetType, RawType } from './robj';
+import { ChannelMain } from './chan/channel';
+
+type Promisify<T> = T extends (...args: any) => any
+  ? (...args: Parameters<T>) => Promisify<RemoteProperty<ReturnType<T>>>
+  : T extends Promise<unknown>
+  ? T
+  : Promise<T>;
+type RemoteProperty<P> = P extends RObj ? RProxy<RObj> : Promisify<P>;
+export type RProxy<T> = { [P in keyof T]: RemoteProperty<T[P]> } & {
+  _target: RTargetObj;
+} & {
+  [key: string | number]: RemoteProperty<RObj>;
+};
+
+export function isRProxy(value: any): value is RProxy<RObj> {
+  // An RProxy acts like a function, but with RTargetObj properties
+  return typeof value === 'function' && 'type' in value && 'obj' in value;
+}
+
+export function newRProxy(
+  chan: ChannelMain,
+  target: RTargetPtr,
+  path: (string | number | symbol)[] = []
+): RProxy<RObj> {
+  // Make target callable, so we can trap calls using the apply handler
+  const callableTarget = function () {} as unknown as RTargetObj & {
+    length: unknown;
+    name: unknown;
+    prototype: unknown;
+  };
+  Object.assign(callableTarget, { ...target });
+
+  // Remove some unwanted properties added by the above procedure
+  delete callableTarget.length;
+  delete callableTarget.name;
+  callableTarget.prototype = undefined;
+
+  const proxy = new Proxy(callableTarget, {
+    get: (callableTarget: RTargetObj, prop: string | number | symbol) => {
+      if (prop === '_target') {
+        return target;
+      } else if (prop === 'then') {
+        if (path.length === 0) {
+          return { then: () => proxy };
+        }
+        const r = chan
+          .request({
+            type: 'getRObj',
+            data: {
+              target: target,
+              path: path.map((p) => p.toString()),
+            },
+          })
+          .then((r: RTargetObj) => {
+            if (r.obj instanceof Error) {
+              throw r.obj;
+            }
+            return r.type === RTargetType.PTR ? newRProxy(chan, r) : r.obj;
+          });
+        return r.then.bind(r);
+      }
+      return newRProxy(chan, target, [...path, prop]);
+    },
+    async apply(callableTarget: RTargetObj, _thisArg, args: (RProxy<RObj> | RawType)[]) {
+      const r = (await chan.request({
+        type: 'callRObj',
+        data: {
+          target: target,
+          path: path.map((p) => p.toString()),
+          args: Array.from({ length: args.length }, (_, idx) => {
+            const arg = args[idx];
+            return isRProxy(arg) ? arg._target : { obj: arg, type: RTargetType.RAW };
+          }),
+        },
+      })) as RTargetObj;
+      if (r.obj instanceof Error) {
+        throw r.obj;
+      }
+      return r.type === RTargetType.PTR ? newRProxy(chan, r) : r.obj;
+    },
+  }) as unknown as RProxy<RObj>;
+  return proxy;
+}

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -672,7 +672,7 @@ export function isRObj(value: any): value is RObj {
   return value && typeof value === 'object' && 'type' in value && 'toJs' in value;
 }
 export function isRObjCallable(value: any): value is RObjFunction {
-  return value && typeof isRObj(value) && '_call' in value;
+  return isRObj(value) && '_call' in value;
 }
 
 export function getRObjClass(type: RType): typeof RObj {

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -226,7 +226,7 @@ export class RObjNull extends RObj {
   }
 }
 
-class RObjSymbol extends RObj {
+export class RObjSymbol extends RObj {
   toJs(): RawType {
     if (this.isUnbound()) {
       return undefined;
@@ -255,7 +255,7 @@ class RObjSymbol extends RObj {
   }
 }
 
-class RObjPairlist extends RObj {
+export class RObjPairlist extends RObj {
   toObject(): { [key: string]: RawType } {
     const d: { [key: string]: RawType } = {};
     for (let next = this as Nullable<RObjPairlist>; !next.isNull(); next = next.cdr()) {
@@ -294,7 +294,7 @@ class RObjPairlist extends RObj {
   }
 }
 
-class RObjList extends RObj {
+export class RObjList extends RObj {
   get length(): number {
     return Module._LENGTH(this.ptr);
   }
@@ -318,7 +318,7 @@ class RObjList extends RObj {
   }
 }
 
-class RObjFunction extends RObj {
+export class RObjFunction extends RObj {
   _call(args: Array<RObj>): RObj {
     const call = RObj.protect(
       new RObjPairlist(Module._Rf_allocVector(RType.Call, args.length + 1))
@@ -334,13 +334,13 @@ class RObjFunction extends RObj {
   }
 }
 
-class RObjString extends RObj {
+export class RObjString extends RObj {
   toJs(): string {
     return UTF8ToString(Module._R_CHAR(this.ptr));
   }
 }
 
-class RObjEnv extends RObj {
+export class RObjEnv extends RObj {
   ls(all = false, sorted = true): string[] {
     return new RObjCharacter(Module._R_lsInternal3(this.ptr, all, sorted)).toJs();
   }
@@ -424,7 +424,7 @@ abstract class RObjAtomicVector extends RObj {
 }
 
 type RLogical = boolean | 'NA' | undefined;
-class RObjLogical extends RObjAtomicVector {
+export class RObjLogical extends RObjAtomicVector {
   getLogical(idx: number): RLogical {
     return this.get(idx).toJs()[0];
   }
@@ -454,7 +454,7 @@ class RObjLogical extends RObjAtomicVector {
   }
 }
 
-class RObjInt extends RObjAtomicVector {
+export class RObjInt extends RObjAtomicVector {
   getNumber(idx: number): number {
     return this.get(idx).toArray()[0];
   }
@@ -474,7 +474,7 @@ class RObjInt extends RObjAtomicVector {
   }
 }
 
-class RObjReal extends RObjAtomicVector {
+export class RObjReal extends RObjAtomicVector {
   getNumber(idx: number): number {
     return this.get(idx).toArray()[0];
   }
@@ -494,7 +494,7 @@ class RObjReal extends RObjAtomicVector {
   }
 }
 
-class RObjComplex extends RObjAtomicVector {
+export class RObjComplex extends RObjAtomicVector {
   getComplex(idx: number): Complex {
     return this.get(idx).toJs()[0];
   }
@@ -523,7 +523,7 @@ class RObjComplex extends RObjAtomicVector {
   }
 }
 
-class RObjCharacter extends RObjAtomicVector {
+export class RObjCharacter extends RObjAtomicVector {
   getString(idx: number): string {
     return this.get(idx).toJs()[0];
   }
@@ -549,7 +549,7 @@ class RObjCharacter extends RObjAtomicVector {
   }
 }
 
-class RObjRawdata extends RObjAtomicVector {
+export class RObjRawdata extends RObjAtomicVector {
   getNumber(idx: number): number {
     return this.get(idx).toArray()[0];
   }

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -246,6 +246,19 @@ export class RObj {
     return sub;
   }
 
+  pluck(...path: (string | number)[]): RObj | undefined {
+    try {
+      const result = path.reduce((obj: RObj, prop: string | number): RObj => obj.get(prop), this);
+      return result.isNull() ? undefined : result;
+    } catch (err) {
+      // Deal with subscript out of bounds error
+      if (err === Infinity) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
   static get globalEnv(): RObj {
     return RObj.wrap(getValue(Module._R_GlobalEnv, '*'));
   }
@@ -415,6 +428,11 @@ export class RObjFunction extends RObj {
       c = c.cdr();
     }
     return RObj.wrap(Module._Rf_eval(call.ptr, RObj.globalEnv.ptr));
+  }
+  exec(...args: (RawType | RObj)[]): RObj {
+    return this._call(
+      args.map((arg) => (isRObj(arg) ? arg : new RObj({ obj: arg, type: RTargetType.RAW })))
+    );
   }
 }
 


### PR DESCRIPTION
With this PR R objects can be interacted with on the main thread through an RProxy. `pluck()` and `exec()` are also implemented in this PR.

e.g.
```
> r = await webR.evalRCode('c(1,2,3,42)')
< Proxy {obj: 21230504, type: 'PTR', prototype: undefined}
> await r[4].toJs()
< Float64Array [42, buffer: ...]
```

Note: a reminder that R's 1 based indexing is currently used when calling `get()` or getting via the proxy with `[]`.