### PR TITLE
eval_R_7: Set hooks for R object proxies

### DIFF
--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -55,10 +55,12 @@ export interface Module extends EmscriptenModule {
   _Rf_allocVector: (type: RType, len: number) => RPtr;
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
+  _Rf_install: (ptr: number) => RPtr;
   _Rf_installTrChar: (name: RPtr) => RPtr;
   _Rf_lang1: (ptr1: RPtr) => RPtr;
   _Rf_lang2: (ptr1: RPtr, ptr2: RPtr) => RPtr;
   _Rf_lang3: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr) => RPtr;
+  _Rf_lang4: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr, ptr4: RPtr) => RPtr;
   _Rf_mkChar: (ptr: number) => RPtr;
   _Rf_mkString: (ptr: number) => RPtr;
   _Rf_protect: (ptr: RPtr) => RPtr;

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -259,6 +259,26 @@ export class RObj {
     }
   }
 
+  set(prop: string | number, value: RObj) {
+    let idx: RPtr;
+    let char: RPtr = 0;
+    if (typeof prop === 'number') {
+      idx = Module._Rf_protect(Module._Rf_ScalarInteger(prop));
+    } else {
+      char = allocateUTF8(prop);
+      idx = Module._Rf_protect(Module._Rf_mkString(char));
+    }
+    const assign = allocateUTF8('[[<-');
+    const call = Module._Rf_protect(
+      Module._Rf_lang4(Module._Rf_install(assign), this.ptr, idx, value.ptr)
+    );
+    const val = RObj.wrap(Module._Rf_eval(call, RObj.globalEnv.ptr));
+    Module._Rf_unprotect(2);
+    if (char) Module._free(char);
+    Module._free(assign);
+    return val;
+  }
+
   static get globalEnv(): RObj {
     return RObj.wrap(getValue(Module._R_GlobalEnv, '*'));
   }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -30,6 +30,13 @@ export class WebR {
     return await this.#chan.initialised;
   }
 
+  async ready() {
+    /* Create a barrier and await until R has caught up.
+       TODO: Handle this using a busy signal within webR.
+     */
+    return await this.#chan.request({ type: 'tic' });
+  }
+
   async read(): Promise<Message> {
     return await this.#chan.read();
   }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -81,6 +81,9 @@ function inputOrDispatch(chan: ChannelWorker): string {
           case 'getFSNode':
             write(getFSNode(reqMsg.data.path as string));
             continue;
+          case 'tic':
+            write('toc');
+            continue;
           case 'evalRCode': {
             const data = reqMsg.data as {
               code: string;


### PR DESCRIPTION
With this PR R proxy objects can be set, through the `set` proxy hook.

Internally, this works by calling R's `[[<-` operator.

Since `set` can't return an async, a barrier has been made and can be used to sync changes before continuing. The `ready()` function sends a "tic" request, and waits for a "toc" response. We know that once the "toc" response has arrived, webR/R has caught up with all our previous requests in the queue.

In the future, this can probably be replaced by a webR busy flag.

```
> r = await webR.evalRCode('c(1,2,3,42)')
> r[4]=4
> await webR.ready()
> await r.toJs()
< Float64Array(4) [1, 2, 3, 4, buffer: ...]
``` 
