### PR TITLE
GitHub Actions workflow files to build and deploy webR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build webR
+
+on:
+  push:
+    branches:
+      - "main"
+      - "build_ci"
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: georgestagg/webr-flang:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure webR
+        run: ./configure
+      - name: Copy flang into webR tree
+        run: cp -r /opt/flang/wasm . && cp -r /opt/flang/host . && cp /opt/flang/emfc ./tools/flang
+      - name: Build webR
+        run: cd /opt/emsdk && . emsdk_env.sh && cd - && make
+        shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Build, test and deploy webR
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: georgestagg/webr-flang:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure webR for flang
+        run: ./configure
+      - name: Copy flang into webR tree
+        run: cp -r /opt/flang/wasm . && cp -r /opt/flang/host . && cp /opt/flang/emfc ./tools/flang
+      - name: Build webR
+        run: cd /opt/emsdk && . emsdk_env.sh && cd - && make
+        shell: bash
+      - name: Archive webR build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: webr-dist
+          path: |
+            dist
+            !dist/index.html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: deploy
+    steps:
+      - name: Download build archive
+        uses: actions/download-artifact@v3
+        with:
+          name: webr-dist
+      - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.R2_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_S3_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          SOURCE_DIR: .
+          DEST_DIR: ${{ github.ref_name }}/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
-name: Build webR
+name: Build and test webR
 
 on:
-  push:
-    branches:
-      - "main"
-      - "build_ci"
   pull_request:
     branches:
       - "main"
@@ -16,7 +12,7 @@ jobs:
     container: georgestagg/webr-flang:latest
     steps:
       - uses: actions/checkout@v3
-      - name: Configure webR
+      - name: Configure webR for flang
         run: ./configure
       - name: Copy flang into webR tree
         run: cp -r /opt/flang/wasm . && cp -r /opt/flang/host . && cp /opt/flang/emfc ./tools/flang


### PR DESCRIPTION
Two GitHub workflow files are added:

* `test.yml` is triggered on pull requests to `main`. This workflow builds webR as a test.
* `deploy.yml` is triggered on a push to `main`, or creation of a tag matching the pattern `v*.*`. This builds webR, creates a build artefact using the contents of the resulting `dist` directory, then uploads the contents to a Cloudflare R2 bucket using settings configured in this repo's "deploy" environment, using the commit's branch or tag name as a destination subdirectory.

The webR public CDN will be powered by a Cloudflare worker. The worker will serve webR from the R2 bucket, with the relevant cross-origin headers set. In future the worker can also directly handle caching via the Cloudflare cache API.

Once unit testing has been setup and merged, it should be trivial to add `make check` to the workflow files.

Building `flang` takes too much time and processing power for a GitHub action. I have pre-compiled a version of `flang` compatible with webR in a Docker image, and have uploaded the image to Dockerhub at `georgestagg/webr-flang`. This Docker image has been set as the container for building webR. The build script copies the precompiled version of `flang` into the webR build tree, ready to use, before running `make`.