### PR TITLE
Fix R signrank and wilcox functions

### DIFF
--- a/patches/R-4.1.3/fix-signrank-wilcox.diff
+++ b/patches/R-4.1.3/fix-signrank-wilcox.diff
@@ -1,0 +1,32 @@
+Index: R-4.1.3/src/library/stats/src/distn.c
+===================================================================
+--- R-4.1.3.orig/src/library/stats/src/distn.c
++++ R-4.1.3/src/library/stats/src/distn.c
+@@ -458,13 +458,13 @@ DEFMATH4_2(qtukey)
+ extern void signrank_free(void);
+ extern void wilcox_free(void);
+ 
+-SEXP stats_signrank_free(void)
++SEXP stats_signrank_free(SEXP args)
+ {
+     signrank_free();
+     return R_NilValue;
+ }
+ 
+-SEXP stats_wilcox_free(void)
++SEXP stats_wilcox_free(SEXP args)
+ {
+     wilcox_free();
+     return R_NilValue;
+Index: R-4.1.3/src/library/stats/src/statsR.h
+===================================================================
+--- R-4.1.3.orig/src/library/stats/src/statsR.h
++++ R-4.1.3/src/library/stats/src/statsR.h
+@@ -203,5 +203,5 @@ SEXP Fisher_sim(SEXP sr, SEXP sc, SEXP s
+ SEXP chisq_sim(SEXP sr, SEXP sc, SEXP sB, SEXP E);
+ SEXP d2x2xk(SEXP sK, SEXP sm, SEXP sn, SEXP st, SEXP srn);
+ 
+-SEXP stats_signrank_free(void);
+-SEXP stats_wilcox_free(void);
++SEXP stats_signrank_free(SEXP args);
++SEXP stats_wilcox_free(SEXP args);

--- a/patches/R-4.1.3/series
+++ b/patches/R-4.1.3/series
@@ -15,3 +15,4 @@ tre-fix-rf_error-args.diff
 emscripten-disable-bcEval.diff
 emscripten-xhr-download.diff
 eval-r-code.diff
+fix-signrank-wilcox.diff


### PR DESCRIPTION
Currently functions such as `qwilcox` and `dsignrank` throw a
`RuntimeError`, caused by a WASM function signature mismatch.

Emscripten does not deal with function pointer casting well, so
this commit adds an unused `SEXP args` argument to the functions
`stats_signrank_free` and `stats_wilcox_free`, located in the default
stats library, to help work around this.