### PR TITLE
Reintroduce function call semantics for `RFunction` type objects

### DIFF
--- a/src/tests/webR/proxy.test.ts
+++ b/src/tests/webR/proxy.test.ts
@@ -1,4 +1,5 @@
 import { WebR } from '../../webR/webr-main';
+import { RDouble, RFunction } from '../../webR/robj';
 import util from 'util';
 
 const webR = new WebR({
@@ -23,6 +24,25 @@ test('RProxy _target property', async () => {
   expect(result._target).toHaveProperty('methods');
   expect(result._target).toHaveProperty('obj');
   expect(result._target.obj).toEqual(expect.any(Number));
+});
+
+test('RFunctions can be invoked via the proxy apply hook', async () => {
+  const fn = (await webR.evalRCode('factorial')) as RFunction;
+  const result = (await fn(8)) as RDouble;
+  expect(await result.toNumber()).toEqual(40320);
+});
+
+test('RFunctions can be returned by R functions and invoked via the apply hook', async () => {
+  const fn = (await webR.evalRCode('function(x) function (y) {x*y}')) as RFunction;
+  const invoke = (await fn(5)) as RFunction;
+  const result = (await invoke(7)) as RDouble;
+  expect(await result.toNumber()).toEqual(35);
+});
+
+test('Other R objects cannot use the apply hook', async () => {
+  const notFn = await webR.evalRCode('123');
+  // @ts-expect-error Deliberate type error to test Error thrown
+  expect(() => notFn(8)).toThrow('is not a function');
 });
 
 afterAll(() => {

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -8,7 +8,6 @@ export type RObject = RProxy<RObjImpl>;
 export type RNull = RProxy<RObjNull>;
 export type RSymbol = RProxy<RObjSymbol>;
 export type RPairlist = RProxy<RObjPairlist>;
-export type RFunction = RProxy<RObjFunction>;
 export type REnvironment = RProxy<RObjEnvironment>;
 export type RString = RProxy<RObjString>;
 export type RLogical = RProxy<RObjLogical>;
@@ -18,6 +17,8 @@ export type RComplex = RProxy<RObjComplex>;
 export type RCharacter = RProxy<RObjCharacter>;
 export type RList = RProxy<RObjList>;
 export type RRaw = RProxy<RObjRaw>;
+// RFunction proxies are callable
+export type RFunction = RProxy<RObjFunction> & ((...args: unknown[]) => Promise<unknown>);
 
 export enum RType {
   Null = 0,
@@ -777,7 +778,7 @@ export function isRObjImpl(value: any): value is RObjImpl {
  */
 export function isRObject(value: any): value is RObject {
   return (
-    typeof value === 'object' &&
+    (typeof value === 'object' || typeof value === 'function') &&
     'type' in value &&
     'obj' in value &&
     'methods' in value &&


### PR DESCRIPTION
With this PR, as our R proxies are constructed a test is made to see if the R object has the `exec` method. If it does, it is assumed the object is an R function.

Proxies to R functions are then constructed with an empty function as the base target object. With this, the proxy becomes callable, and a proxy `apply` hook can be used.

An `apply` hook is created such that `await foo(...)` simply becomes a shortcut for `await foo.exec(...)`. In future we can add subtle differences in the argument types for calling via the hook vs invoking `exec` directly, if we would like to do so.

The Typescript alias for `RFunction` is updated to include the information that it is callable.

Unit tests are added to check that `RFunction`s are callable, and some other R object is not.
