### PR TITLE
Expose the R Object constructor to the main thread

### DIFF
--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -1,5 +1,6 @@
 import { WebR } from '../../webR/webr-main';
 import { Message } from '../../webR/chan/message';
+import { RDouble } from '../../webR/robj';
 
 const webR = new WebR({
   WEBR_URL: '../dist/',
@@ -66,6 +67,12 @@ describe('Evaluate R code', () => {
     await expect(res).resolves.not.toThrow();
     expect((await webR.read()).data).toBe('Hello, stderr!');
   });
+});
+
+test('Create simple R object from the main thread', async () => {
+  const jsObj = [1, 2, 3, 6, 11, 23, 47, 106, 235];
+  const rObj = (await webR.newRObject(jsObj)) as RDouble;
+  expect(Array.from(await rObj.toArray())).toEqual(jsObj);
 });
 
 afterAll(() => {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -13,6 +13,7 @@ import {
   RTargetType,
   RType,
   RawType,
+  RTargetRaw,
 } from './robj';
 
 let initialised = false;
@@ -83,6 +84,22 @@ function inputOrDispatch(chan: ChannelWorker): string {
             };
             try {
               write(evalRCode(data.code, data.env, data.options));
+            } catch (_e) {
+              const e = _e as Error;
+              write({
+                type: RTargetType.ERR,
+                obj: { name: e.name, message: e.message, stack: e.stack },
+              });
+            }
+            continue;
+          }
+          case 'newRObject': {
+            const data = reqMsg.data as {
+              obj: RTargetRaw;
+            };
+            try {
+              const res = new RObjImpl(data.obj);
+              write({ obj: res.ptr, methods: RObjImpl.getMethods(res), type: RTargetType.PTR });
             } catch (_e) {
               const e = _e as Error;
               write({


### PR DESCRIPTION
Allows one to create an R object from a JS object from the main thread with a new `webR.newRObject` function. The request is passed onto the worker thread where the the `RObjImpl` constructor is then used.