### PR TITLE
Rework the "Console" webR app to work with callbacks and manage the async infinite loop

### DIFF
--- a/src/console/console.ts
+++ b/src/console/console.ts
@@ -1,3 +1,4 @@
+import { IN_NODE } from '../webR/compat';
 import { WebR, WebROptions } from '../webR/webr-main';
 
 /**
@@ -45,7 +46,7 @@ import { WebR, WebROptions } from '../webR/webr-main';
  */
 export class Console {
   webR: WebR;
-  canvas: HTMLCanvasElement;
+  canvas: HTMLCanvasElement | undefined;
   #stdout;
   #stderr;
   #prompt;
@@ -80,9 +81,11 @@ export class Console {
     }
   ) {
     this.webR = new WebR(options);
-    this.canvas = document.createElement('canvas');
-    this.canvas.setAttribute('width', '1008');
-    this.canvas.setAttribute('height', '1008');
+    if (!IN_NODE) {
+      this.canvas = document.createElement('canvas');
+      this.canvas.setAttribute('width', '1008');
+      this.canvas.setAttribute('height', '1008');
+    }
     this.#stdout = callbacks.stdout || this.#defaultStdout;
     this.#stderr = callbacks.stderr || this.#defaultStderr;
     this.#prompt = callbacks.prompt || this.#defaultPrompt;
@@ -127,6 +130,9 @@ export class Console {
    * @param {string} exec - The canvas API command as a text string
    */
   #defaultCanvasExec = (exec: string) => {
+    if (IN_NODE) {
+      throw new Error('Plotting with HTML canvas is not yet supported under Node');
+    }
     Function(`this.getContext('2d').${exec}`).bind(this.canvas)();
   };
 

--- a/src/console/console.ts
+++ b/src/console/console.ts
@@ -1,14 +1,162 @@
-import { WebR } from '../webR/webr-main';
+import { WebR, WebROptions } from '../webR/webr-main';
 
-(async () => {
-  const webR = new WebR();
+/**
+ * @callback ConsoleCallback
+ * @param {string} text
+ * @return {void}
+ */
 
-  for (;;) {
-    const output = await webR.read();
-    if (output.type === 'stdout') {
-      console.log(output.data);
-    } else if (output.type === 'stderr') {
-      console.error(output.data);
+/**
+ * Text-based Interactive Console for WebR
+ *
+ * A helper application to assist in creating an interactive R REPL based on
+ * JavaScript callbacks.
+ *
+ * Callback functions ``stdout`` and ``stderr`` are called with a single line
+ * of output as the first argument. The default implementation of `stdout` and
+ * `stderr` writes to the console using `console.log` and `console.error`.
+ *
+ * R code should input by calling the ``stdin`` method with a single line of
+ * textual input.
+ *
+ * The ``prompt`` callback function is called when webR produces a prompt at
+ * the REPL console and is therefore awaiting user input. The prompt character
+ * (usually ``>`` or ``+``) is given as the first argument to the callback
+ * function. The default implementation of `prompt` shows a JavaScript prompt
+ * asking the user for input, and then sends the user input to `stdin`.
+ *
+ * The ``canvasExec`` callback function is called when webR writes plots to
+ * the built-in HTML canvas graphics device.
+ *
+ * Once constructed, start the Console using the ``run`` method. This method
+ * returns a promise than never resolves. The `run` method consists of an
+ * asynchronous infinite loop that waits for output from the webR worker and
+ * then calls the relevant callbacks.
+ *
+ * @class
+ * @property {WebR} webR The supporting instance of webR.
+ * @property {ConsoleCallback} stdout Called when webR outputs to ``stdout``.
+ * @property {ConsoleCallback} stderr Called when webR outputs to ``stderr``.
+ * @property {ConsoleCallback} prompt Called when webR prompts for input.
+ * @property {ConsoleCallback} canvasExec Called when webR writes to the HTML
+ * canvas element.
+ * @property {HTMLCanvasElement} canvas The HTML canvas element written to
+ * by default.
+ */
+export class Console {
+  webR: WebR;
+  canvas: HTMLCanvasElement;
+  #stdout;
+  #stderr;
+  #prompt;
+  #canvasExec;
+
+  /**
+   * @constructor
+   * @param {Object} callbacks
+   * @param {ConsoleCallback} callbacks.stdout Called when webR outputs
+   * to stdout.
+   * @param {ConsoleCallback} callbacks.stderr Called when webR outputs
+   * to stderr.
+   * @param {ConsoleCallback} callbacks.prompt Called when webR prompts
+   * for input.
+   * @param {ConsoleCallback} callbacks.canvasExec Called when webR writes
+   * to HTML canvas.
+   * @param {WebROptions} options The options for the new webR instance.
+   */
+  constructor(
+    callbacks: {
+      stdout?: (text: string) => void;
+      stderr?: (text: string) => void;
+      prompt?: (text: string) => void;
+      canvasExec?: (text: string) => void;
+    } = {},
+    options: WebROptions = {
+      REnv: {
+        R_HOME: '/usr/lib/R',
+        R_ENABLE_JIT: '0',
+        R_DEFAULT_DEVICE: 'canvas',
+      },
+    }
+  ) {
+    this.webR = new WebR(options);
+    this.canvas = document.createElement('canvas');
+    this.canvas.setAttribute('width', '1008');
+    this.canvas.setAttribute('height', '1008');
+    this.#stdout = callbacks.stdout || this.#defaultStdout;
+    this.#stderr = callbacks.stderr || this.#defaultStderr;
+    this.#prompt = callbacks.prompt || this.#defaultPrompt;
+    this.#canvasExec = callbacks.canvasExec || this.#defaultCanvasExec;
+  }
+
+  /**
+   * Write a line of input to webR's REPL through ``stdin``
+   * @param {string} input - A line of input text
+   */
+  stdin(input: string) {
+    this.webR.writeConsole(input + '\n');
+  }
+
+  /**
+   * The default function called when webR outputs to ``stdout``
+   * @param {string} text - The line sent to stdout by webR
+   */
+  #defaultStdout = (text: string) => {
+    console.log(text);
+  };
+
+  /**
+   * The default function called when webR outputs to ``stderr``
+   * @param {string} text - The line sent to stderr by webR
+   */
+  #defaultStderr = (text: string) => {
+    console.error(text);
+  };
+
+  /**
+   * The default function called when webR writes out a prompt
+   * @param {string} text - The text content of the prompt
+   */
+  #defaultPrompt = (text: string) => {
+    const input = prompt(text);
+    if (input) this.stdin(`${input}\n`);
+  };
+
+  /**
+   * The default function called when webR writes to HTML canvas
+   * @param {string} exec - The canvas API command as a text string
+   */
+  #defaultCanvasExec = (exec: string) => {
+    Function(`this.getContext('2d').${exec}`).bind(this.canvas)();
+  };
+
+  /**
+   * Start the webR console
+   *
+   * Start the infinite loop waiting for output from webR and dispatching
+   * callbacks based on the message recieved.
+   *
+   * The promise returned by this asynchronous function never resolves.
+   */
+  async run() {
+    for (;;) {
+      const output = await this.webR.read();
+      switch (output.type) {
+        case 'stdout':
+          this.#stdout(output.data as string);
+          break;
+        case 'stderr':
+          this.#stderr(output.data as string);
+          break;
+        case 'prompt':
+          this.#prompt(output.data as string);
+          break;
+        case 'canvasExec':
+          this.#canvasExec(output.data as string);
+          break;
+        default:
+          console.warn(`Unhandled output type for webR Console: ${output.type}.`);
+      }
     }
   }
-})();
+}

--- a/src/esbuild.js
+++ b/src/esbuild.js
@@ -46,10 +46,4 @@ function build({ input, output, platform, minify }) {
     platform: 'neutral',
     minify: true,
   },
-  {
-    input: "console/console.ts",
-    output: "../dist/console.mjs",
-    platform: 'neutral',
-    minify: true,
-  },
 ].map(build);

--- a/src/tests/console/console.test.ts
+++ b/src/tests/console/console.test.ts
@@ -1,0 +1,35 @@
+import { Console } from '../../webR/webr-main';
+import { sleep } from '../../webR/utils';
+
+const stdout = jest.fn();
+const stderr = jest.fn();
+const prompt = jest.fn();
+const con = new Console(
+  {
+    stdout: stdout,
+    stderr: stderr,
+    prompt: prompt,
+  },
+  {
+    WEBR_URL: '../dist/',
+  }
+);
+con.run();
+
+test('Start up the REPL and wait for user input prompt', async () => {
+  await con.webR.init();
+  expect(stdout).toHaveBeenCalledWith('Platform: wasm32-unknown-emscripten (32-bit)');
+  expect(prompt).toHaveBeenCalledWith('> ');
+});
+
+test('Take input and write to stdout', async () => {
+  con.stdin('42');
+  await sleep(500);
+  expect(stdout).toHaveBeenCalledWith('[1] 42');
+});
+
+test('Generate an error message and write to stdout', async () => {
+  con.stdin(';');
+  await sleep(500);
+  expect(stderr).toHaveBeenCalledWith('Error: unexpected \';\' in ";"');
+});

--- a/src/tests/console/console.test.ts
+++ b/src/tests/console/console.test.ts
@@ -1,14 +1,16 @@
 import { Console } from '../../webR/webr-main';
-import { sleep } from '../../webR/utils';
+import { promiseHandles } from '../../webR/utils';
 
 const stdout = jest.fn();
 const stderr = jest.fn();
 const prompt = jest.fn();
+
+let waitForPrompt = promiseHandles();
 const con = new Console(
   {
     stdout: stdout,
     stderr: stderr,
-    prompt: prompt,
+    prompt: (line: string) => waitForPrompt.resolve(prompt(line)),
   },
   {
     WEBR_URL: '../dist/',
@@ -23,14 +25,16 @@ test('Start up the REPL and wait for user input prompt', async () => {
 });
 
 test('Take input and write to stdout', async () => {
+  waitForPrompt = promiseHandles();
   con.stdin('42');
-  await sleep(500);
+  await waitForPrompt.promise;
   expect(stdout).toHaveBeenCalledWith('[1] 42');
 });
 
 test('Generate an error message and write to stdout', async () => {
+  waitForPrompt = promiseHandles();
   con.stdin(';');
-  await sleep(500);
+  await waitForPrompt.promise;
   expect(stderr).toHaveBeenCalledWith('Error: unexpected \';\' in ";"');
 });
 

--- a/src/tests/console/console.test.ts
+++ b/src/tests/console/console.test.ts
@@ -33,3 +33,7 @@ test('Generate an error message and write to stdout', async () => {
   await sleep(500);
   expect(stderr).toHaveBeenCalledWith('Error: unexpected \';\' in ";"');
 });
+
+afterAll(() => {
+  return con.webR.close();
+});

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -4,7 +4,7 @@ import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy } from './proxy';
 import { RTargetObj, RTargetType, RObject, isRObject } from './robj';
 
-export { Console } from '../console/console';
+export { Console, ConsoleCallbacks } from '../console/console';
 
 export type FSNode = {
   id: number;

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -4,6 +4,8 @@ import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy } from './proxy';
 import { RTargetObj, RTargetType, RObject, isRObject } from './robj';
 
+export { Console } from '../console/console';
+
 export type FSNode = {
   id: number;
   name: string;


### PR DESCRIPTION
This PR reworks the included Console app so that it is constructed by providing callbacks for `stdout`, `stderr` etc. This may be useful and easier to use for users more familiar with how Emscripten apps and Pyodide starts up by default (without use of async workers), where callbacks are provided.

 * Default callbacks are included: prompting the user for input with a JS alert, sending output to the JS console, and plotting with `canvas` graphic device. It is expected for users to override these defaults if they use `Console` within their own project.

* The default plotting callback writes stores output in the instance property `canvas`, a `HTMLCanvasElement` that can be appended into the web page. For the moment, plotting throws an error when running under Node, explaining that HTML canvas is not currently available there. There is a node package replicating the Canvas API that could be added later.

* Rather than building a separate output with `esbuild`, `Console` is now included in `webr.mjs` via a re-export.

* The `Console` app manages the async infinite loop around the webR communication channels for the user. The user simply needs to call `Console.run()` to start reading from webR output. It is important this function is not `await`ed, it never returns.

