### PR TITLE
When invoking RFunction via proxy apply hook, convert the result into JS automatically

### DIFF
--- a/src/tests/webR/proxy.test.ts
+++ b/src/tests/webR/proxy.test.ts
@@ -1,5 +1,5 @@
 import { WebR } from '../../webR/webr-main';
-import { RDouble, RFunction } from '../../webR/robj';
+import { RFunction } from '../../webR/robj';
 import util from 'util';
 
 const webR = new WebR({
@@ -26,15 +26,15 @@ test('RProxy _target property', async () => {
 
 test('RFunctions can be invoked via the proxy apply hook', async () => {
   const fn = (await webR.evalRCode('factorial')).result as RFunction;
-  const result = (await fn(8)) as RDouble;
-  expect(await result.toNumber()).toEqual(40320);
+  const result = (await fn(8)) as number[];
+  expect(result[0]).toEqual(40320);
 });
 
 test('RFunctions can be returned by R functions and invoked via the apply hook', async () => {
   const fn = (await webR.evalRCode('function(x) function (y) {x*y}')).result as RFunction;
   const invoke = (await fn(5)) as RFunction;
-  const result = (await invoke(7)) as RDouble;
-  expect(await result.toNumber()).toEqual(35);
+  const result = (await invoke(7)) as number[];
+  expect(result[0]).toEqual(35);
 });
 
 test('Other R objects cannot use the apply hook', async () => {

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -1,5 +1,5 @@
 import { RTargetType, RTargetPtr, isRObject, RTargetObj } from './robj';
-import { RObjImpl, RObjFunction, RawType } from './robj';
+import { RObjImpl, RObjFunction, RawType, isRFunction } from './robj';
 import { ChannelMain } from './chan/channel';
 
 /** Obtain a union of the keys corresponding to methods of a given class T
@@ -93,7 +93,9 @@ export function newRProxy(chan: ChannelMain, target: RTargetPtr): RProxy<RObjImp
         };
       }
     },
-    apply: async (_: RTargetObj, _thisArg, args: (RawType | RProxy<RObjImpl>)[]) =>
-      (newRProxy(chan, target) as RProxy<RObjFunction>).exec(...args),
+    apply: async (_: RTargetObj, _thisArg, args: (RawType | RProxy<RObjImpl>)[]) => {
+      const res = await (newRProxy(chan, target) as RProxy<RObjFunction>).exec(...args);
+      return isRFunction(res) ? res : res.toJs();
+    },
   }) as unknown as RProxy<RObjImpl>;
 }

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -786,6 +786,16 @@ export function isRObject(value: any): value is RObject {
   );
 }
 
+/**
+ * Test for an RFunction instance
+ *
+ * @param {any} value The object to test.
+ * @return {boolean} True if the object is an instance of an RFunction.
+ */
+export function isRFunction(value: any): value is RFunction {
+  return isRObject(value) && 'methods' in value._target && value._target.methods.includes('exec');
+}
+
 export function getRObjClass(type: RType): typeof RObjImpl {
   const typeClasses: { [key: number]: typeof RObjImpl } = {
     [RType.Null]: RObjNull,


### PR DESCRIPTION
When using the `foo()` proxy apply hook magic with a prepared `RFunction` object `foo`, the R machinery is hidden away. I think it makes sense in this case to convert the result to a JS object before returning.

*EDIT*: When returning another `RFunction`, the conversion is skipped since an `RFunction` can be invoked through the proxy apply hook directly, without a conversion to JavaScript required. Since the proxy apply hook is already fairly magic and typed as returning `any` I don't think much is lost in the ambiguity. A case could be made that `RFunction`'s  `toJs` method should return a JS function anyway, but this would probably have to be done in another PR since transferring JS functions from the worker to main thread will require some thought and extra machinery.

The current behaviour (returning an `RObject`) can still be done by invoking the `exec()` method on the object directly. Probably later we can further organise the magic so that automatic argument conversion is also done only in the case of using the proxy apply hook.