### PR TITLE
Change how R lists, pairlists and atomic vectors are converted to JavaScript by default

### DIFF
--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -43,8 +43,9 @@ test('Get RObject type as a string', async () => {
 describe('Working with R lists and vectors', () => {
   test('Get R object attributes', async () => {
     const vector = (await webR.evalRCode('c(a=1, b=2, c=3)')).result;
-    const value = await vector.attrs();
-    expect(await value.toJs()).toEqual({ names: ['a', 'b', 'c'] });
+    const value = (await vector.attrs()) as RList;
+    const attrs = await value.toArray();
+    expect(attrs[0]).toEqual({ names: ['a', 'b', 'c'] });
   });
 
   test('Get R object names', async () => {
@@ -68,9 +69,9 @@ describe('Working with R lists and vectors', () => {
   test('Get an item with [ operator', async () => {
     const vector = (await webR.evalRCode('list(a=1+4i, b=2-5i, c=3+6i)')).result;
     let value = await vector.subset('b');
-    expect(await value.toJs()).toEqual({ b: [{ re: 2, im: -5 }] });
+    expect(await value.toJs()).toEqual([{ b: [{ re: 2, im: -5 }] }]);
     value = await vector.subset(3);
-    expect(await value.toJs()).toEqual({ c: [{ re: 3, im: 6 }] });
+    expect(await value.toJs()).toEqual([{ c: [{ re: 3, im: 6 }] }]);
   });
 
   test('Get an item with $ operator', async () => {
@@ -109,7 +110,9 @@ describe('Working with R lists and vectors', () => {
   test('Convert an R pairlist to JS', async () => {
     const result = (await webR.evalRCode('as.pairlist(list(x="a", y="b", z="c"))'))
       .result as RPairlist;
-    expect(await result.toJs()).toEqual({ x: ['a'], y: ['b'], z: ['c'] });
+    expect(await result.toJs()).toEqual([{ x: ['a'] }, { y: ['b'] }, { z: ['c'] }]);
+    expect(await result.toObject()).toEqual({ x: ['a'], y: ['b'], z: ['c'] });
+    expect(await result.values()).toEqual([['a'], ['b'], ['c']]);
   });
 
   test('R list includes method', async () => {
@@ -119,8 +122,9 @@ describe('Working with R lists and vectors', () => {
 
   test('Convert an R list to JS', async () => {
     const result = (await webR.evalRCode('list(x="a", y="b", z="c")')).result as RList;
-    expect(await result.toJs()).toEqual({ x: ['a'], y: ['b'], z: ['c'] });
-    expect(await result.toArray()).toEqual([['a'], ['b'], ['c']]);
+    expect(await result.toJs()).toEqual([{ x: ['a'] }, { y: ['b'] }, { z: ['c'] }]);
+    expect(await result.toObject()).toEqual({ x: ['a'], y: ['b'], z: ['c'] });
+    expect(await result.values()).toEqual([['a'], ['b'], ['c']]);
   });
 
   test('Convert an R double atomic vector to JS', async () => {

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -46,7 +46,7 @@ describe('Working with R lists and vectors', () => {
     const vector = (await webR.evalRCode('c(a=1, b=2, c=3)')).result;
     const value = (await vector.attrs()) as RList;
     const attrs = await value.toObject();
-    expect(attrs.names).toEqual(expect.objectContaining({ values: ['a', 'b', 'c'] }));
+    expect(attrs.names).toEqual(expect.objectContaining({ names: null, values: ['a', 'b', 'c'] }));
   });
 
   test('Get R object names', async () => {
@@ -56,7 +56,7 @@ describe('Working with R lists and vectors', () => {
 
     vector = (await webR.evalRCode('c(1, 2, 3)')).result;
     value = await vector.names();
-    expect(await value).toBeUndefined();
+    expect(await value).toEqual(null);
   });
 
   test('Get an item with [[ operator', async () => {
@@ -69,13 +69,13 @@ describe('Working with R lists and vectors', () => {
 
   test('Get an item with [ operator', async () => {
     const vector = (await webR.evalRCode('list(a=1+4i, b=2-5i, c=3+6i)')).result;
-    const val1 = (await vector.subset('b')) as RComplex;
+    const val1 = (await vector.subset('b')) as RList;
     const obj1 = await val1.toObject();
-    expect(obj1.b).toEqual(expect.objectContaining({ values: [{ re: 2, im: -5 }] }));
+    expect(obj1.b).toEqual(expect.objectContaining({ names: null, values: [{ re: 2, im: -5 }] }));
 
-    const val2 = (await vector.subset(3)) as RComplex;
+    const val2 = (await vector.subset(3)) as RList;
     const obj2 = await val2.toObject();
-    expect(obj2.c).toEqual(expect.objectContaining({ values: [{ re: 3, im: 6 }] }));
+    expect(obj2.c).toEqual(expect.objectContaining({ names: null, values: [{ re: 3, im: 6 }] }));
   });
 
   test('Get an item with $ operator', async () => {
@@ -115,18 +115,18 @@ describe('Working with R lists and vectors', () => {
     const result = (await webR.evalRCode('as.pairlist(list(x="a", y="b", z="c"))'))
       .result as RPairlist;
     const arr = await result.toArray();
-    expect(arr[0]).toEqual(expect.objectContaining({ values: ['a'] }));
-    expect(arr[1]).toEqual(expect.objectContaining({ values: ['b'] }));
-    expect(arr[2]).toEqual(expect.objectContaining({ values: ['c'] }));
+    expect(arr[0]).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
+    expect(arr[1]).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
+    expect(arr[2]).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
     const obj = await result.toObject();
-    expect(obj.x).toEqual(expect.objectContaining({ values: ['a'] }));
-    expect(obj.y).toEqual(expect.objectContaining({ values: ['b'] }));
-    expect(obj.z).toEqual(expect.objectContaining({ values: ['c'] }));
-    const resJs = await result.toJs();
+    expect(obj.x).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
+    expect(obj.y).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
+    expect(obj.z).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
+    const resJs = await result.toTree();
     expect(resJs.names).toEqual(['x', 'y', 'z']);
-    expect(resJs.values[0]).toEqual(expect.objectContaining({ values: ['a'] }));
-    expect(resJs.values[1]).toEqual(expect.objectContaining({ values: ['b'] }));
-    expect(resJs.values[2]).toEqual(expect.objectContaining({ values: ['c'] }));
+    expect(resJs.values[0]).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
+    expect(resJs.values[1]).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
+    expect(resJs.values[2]).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
   });
 
   test('R list includes method', async () => {
@@ -137,80 +137,92 @@ describe('Working with R lists and vectors', () => {
   test('Convert an R list to JS', async () => {
     const result = (await webR.evalRCode('list(x="a", y="b", z="c")')).result as RList;
     const arr = await result.toArray();
-    expect(arr[0]).toEqual(expect.objectContaining({ values: ['a'] }));
-    expect(arr[1]).toEqual(expect.objectContaining({ values: ['b'] }));
-    expect(arr[2]).toEqual(expect.objectContaining({ values: ['c'] }));
+    expect(arr[0]).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
+    expect(arr[1]).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
+    expect(arr[2]).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
     const obj = await result.toObject();
-    expect(obj.x).toEqual(expect.objectContaining({ values: ['a'] }));
-    expect(obj.y).toEqual(expect.objectContaining({ values: ['b'] }));
-    expect(obj.z).toEqual(expect.objectContaining({ values: ['c'] }));
+    expect(obj.x).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
+    expect(obj.y).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
+    expect(obj.z).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
     const resJs = await result.toJs();
     expect(resJs.names).toEqual(['x', 'y', 'z']);
-    expect(resJs.values[0]).toEqual(expect.objectContaining({ values: ['a'] }));
-    expect(resJs.values[1]).toEqual(expect.objectContaining({ values: ['b'] }));
-    expect(resJs.values[2]).toEqual(expect.objectContaining({ values: ['c'] }));
+    expect(resJs.values[0]).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
+    expect(resJs.values[1]).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
+    expect(resJs.values[2]).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
   });
 
   test('Fully undefined names attribute', async () => {
     const list = (await webR.evalRCode('list("a", "b", "c")')).result as RList;
     const pairlist = (await webR.evalRCode('pairlist("a", "b", "c")')).result as RPairlist;
     const atomic = (await webR.evalRCode('c("a", "b", "c")')).result as RCharacter;
-    const listJs = await list.toArrays();
-    const pairlistJs = await pairlist.toArrays();
-    const atomicJs = await atomic.toArrays();
-    expect(listJs.names).toEqual(undefined);
-    expect(pairlistJs.names).toEqual(undefined);
-    expect(atomicJs.names).toEqual(undefined);
+    const listJs = await list.toTree();
+    const pairlistJs = await pairlist.toTree();
+    const atomicJs = await atomic.toTree();
+    expect(listJs.names).toEqual(null);
+    expect(pairlistJs.names).toEqual(null);
+    expect(atomicJs.names).toEqual(null);
   });
 
   test('Partially undefined names attribute', async () => {
     const list = (await webR.evalRCode('list(x="a", y="b", "c")')).result as RList;
     const pairlist = (await webR.evalRCode('pairlist(x="a", y="b", "c")')).result as RPairlist;
     const atomic = (await webR.evalRCode('c(x="a", y="b", "c")')).result as RCharacter;
-    const listJs = await list.toArrays();
-    const pairlistJs = await pairlist.toArrays();
-    const atomicJs = await atomic.toArrays();
-    expect(listJs.names).toEqual(['x', 'y', undefined]);
-    expect(pairlistJs.names).toEqual(['x', 'y', undefined]);
-    expect(atomicJs.names).toEqual(['x', 'y', undefined]);
+    const listJs = await list.toTree();
+    const pairlistJs = await pairlist.toTree();
+    const atomicJs = await atomic.toTree();
+    expect(listJs.names).toEqual(['x', 'y', '']);
+    expect(pairlistJs.names).toEqual(['x', 'y', '']);
+    expect(atomicJs.names).toEqual(['x', 'y', '']);
   });
 
-  test('Automatic indexing when converting to JS object', async () => {
-    const list = (await webR.evalRCode('list(x="a", y="b", "c")')).result as RList;
-    const pairlist = (await webR.evalRCode('pairlist(x="a", y="b", "c")')).result as RPairlist;
-    const atomic = (await webR.evalRCode('c(x="a", y="b", "c")')).result as RCharacter;
-    const listJs = await list.toObject();
-    const pairlistJs = await pairlist.toObject();
-    const atomicJs = await atomic.toObject();
-    expect(Object.keys(listJs)).toEqual(expect.arrayContaining(['3']));
-    expect(Object.keys(pairlistJs)).toEqual(expect.arrayContaining(['3']));
-    expect(Object.keys(atomicJs)).toEqual(expect.arrayContaining(['3']));
-    expect(listJs[3]).toEqual(expect.objectContaining({ values: ['c'] }));
-    expect(pairlistJs[3]).toEqual(expect.objectContaining({ values: ['c'] }));
-    expect(atomicJs[3]).toEqual('c');
+  test('Missing values in names attribute', async () => {
+    const list = (await webR.evalRCode('test = list(1,2); attr(test,"names") <- c("a", NA); test'))
+      .result as RList;
+    const listJs = await list.toTree();
+    expect(listJs.names).toEqual(['a', null]);
+    await expect(list.toObject()).rejects.toThrow('Empty or null key when converting');
   });
 
   test('First key wins when converting R objects to JS objects', async () => {
     const list = (await webR.evalRCode('list(x="a", x="b")')).result as RList;
     const listObj = await list.toObject();
-    expect(listObj.x).toEqual(expect.objectContaining({ values: ['a'] }));
+    expect(listObj.x).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
     const pairlist = (await webR.evalRCode('pairlist(x="a", x="b")')).result as RPairlist;
     const pairlistObj = await pairlist.toObject();
-    expect(pairlistObj.x).toEqual(expect.objectContaining({ values: ['a'] }));
+    expect(pairlistObj.x).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
     const atomic = (await webR.evalRCode('c(x="a", x="b")')).result as RCharacter;
     const atomicObj = await atomic.toObject();
     expect(atomicObj.x).toEqual('a');
   });
 
+  test('Empty key when converting to JS object', async () => {
+    const list = (await webR.evalRCode('list(x="a", y="b", "c")')).result as RList;
+    const pairlist = (await webR.evalRCode('pairlist(x="a", y="b", "c")')).result as RPairlist;
+    const atomic = (await webR.evalRCode('c(x="a", y="b", "c")')).result as RCharacter;
+    await expect(list.toObject()).rejects.toThrow('Empty or null key when converting');
+    await expect(pairlist.toObject()).rejects.toThrow('Empty or null key when converting');
+    await expect(atomic.toObject()).rejects.toThrow('Empty or null key when converting');
+
+    const listJs = await pairlist.toObject({ allowEmptyKey: true });
+    const pairlistJs = await pairlist.toObject({ allowEmptyKey: true });
+    const atomicJs = await atomic.toObject({ allowEmptyKey: true });
+    expect(Object.keys(listJs)).toEqual(expect.arrayContaining(['']));
+    expect(Object.keys(pairlistJs)).toEqual(expect.arrayContaining(['']));
+    expect(Object.keys(atomicJs)).toEqual(expect.arrayContaining(['']));
+    expect(listJs['']).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
+    expect(pairlistJs['']).toEqual(expect.objectContaining({ names: null, values: ['c'] }));
+    expect(atomicJs['']).toEqual('c');
+  });
+
   test('Throw on duplicate keys when converting R objects to JS objects', async () => {
     const list = (await webR.evalRCode('list(x="a", x="b")')).result as RList;
-    const listObj = list.toObject({ throwOnDuplicateKey: true });
+    const listObj = list.toObject({ allowDuplicateKey: false });
     await expect(listObj).rejects.toThrow('Duplicate key when converting');
     const pairlist = (await webR.evalRCode('pairlist(x="a", x="b")')).result as RPairlist;
-    const pairlistObj = pairlist.toObject({ throwOnDuplicateKey: true });
+    const pairlistObj = pairlist.toObject({ allowDuplicateKey: false });
     await expect(pairlistObj).rejects.toThrow('Duplicate key when converting');
     const atomic = (await webR.evalRCode('c(x="a", x="b")')).result as RCharacter;
-    const atomicObj = atomic.toObject({ throwOnDuplicateKey: true });
+    const atomicObj = atomic.toObject({ allowDuplicateKey: false });
     await expect(atomicObj).rejects.toThrow('Duplicate key when converting');
   });
 
@@ -218,7 +230,9 @@ describe('Working with R lists and vectors', () => {
     const polytree = [1, 1, 3, 8, 27, 91, 350, 1376];
     const result = (await webR.evalRCode('c(1, 1, 3, 8, 27, 91, 350, 1376)')).result as RDouble;
     const resJs = await result.toJs();
-    expect(Array.from(resJs.values)).toStrictEqual(polytree);
+    expect(resJs.values).toEqual(polytree);
+    const resArray = await result.toArray();
+    expect(resArray).toEqual(polytree);
   });
 
   test('Convert an R integer atomic vector to JS', async () => {
@@ -226,20 +240,25 @@ describe('Working with R lists and vectors', () => {
     const result = (await webR.evalRCode('as.integer(c(1, 1, 3, 8, 27, 91, 350, 1376))'))
       .result as RInteger;
     const resJs = await result.toJs();
-    expect(Array.from(resJs.values)).toEqual(polytree);
+    expect(resJs.values).toEqual(polytree);
+    const resArray = await result.toArray();
+    expect(resArray).toEqual(polytree);
   });
 
   test('Convert an R logical atomic vector to JS', async () => {
-    const logical = [true, false, 'NA'];
-    const result = (await webR.evalRCode('c(TRUE,FALSE,NA)')).result;
-    expect(await result.toJs()).toEqual(expect.objectContaining({ values: logical }));
+    const logical = [true, false, null];
+    const result = (await webR.evalRCode('c(TRUE, FALSE, NA)')).result as RLogical;
+    const resJs = await result.toJs();
+    expect(resJs.values).toEqual(logical);
+    const resArray = await result.toArray();
+    expect(resArray).toEqual(logical);
   });
 
   test('Convert an R raw atomic vector to JS', async () => {
     const arr = [2, 4, 6];
     const result = (await webR.evalRCode('as.raw(c(2, 4, 6))')).result as RRaw;
     const resJs = await result.toJs();
-    expect(Array.from(resJs.values)).toEqual(arr);
+    expect(resJs.values).toEqual(arr);
   });
 
   test('Convert an R complex atomic vector to JS', async () => {
@@ -247,18 +266,19 @@ describe('Working with R lists and vectors', () => {
       { re: 2, im: -7 },
       { re: 1, im: -8 },
     ];
-    const result = (await webR.evalRCode('c(2-7i, 1-8i)')).result;
-    expect(await result.toJs()).toEqual(expect.objectContaining({ values: cmplx }));
+    const result = (await webR.evalRCode('c(2-7i, 1-8i)')).result as RComplex;
+    const resJs = await result.toJs();
+    expect(resJs.values).toEqual(cmplx);
   });
 
   test('Convert an R scalar double to JS number', async () => {
     const result = (await webR.evalRCode('1234')).result as RDouble;
-    expect(await result.toNumber()).toStrictEqual(1234);
+    expect(await result.toNumber()).toEqual(1234);
   });
 
   test('Convert an R scalar integer to JS number', async () => {
     const result = (await webR.evalRCode('as.integer(5678)')).result as RInteger;
-    expect(await result.toNumber()).toStrictEqual(5678);
+    expect(await result.toNumber()).toEqual(5678);
   });
 
   test('Convert an R scalar logical to JS', async () => {
@@ -267,7 +287,7 @@ describe('Working with R lists and vectors', () => {
     result = (await webR.evalRCode('FALSE')).result as RLogical;
     expect(await result.toLogical()).toEqual(false);
     result = (await webR.evalRCode('NA')).result as RLogical;
-    expect(await result.toLogical()).toEqual('NA');
+    expect(await result.toLogical()).toEqual(null);
   });
 
   test('Convert an R scalar raw to JS number', async () => {
@@ -311,9 +331,14 @@ describe('Working with R environments', () => {
     const env = (await webR.evalRCode('x<-new.env();x$a=TRUE;x$b=FALSE;x$.c=NA;x'))
       .result as REnvironment;
     const envJs = await env.toJs();
-    expect(envJs['.c']).toEqual(expect.objectContaining({ values: ['NA'] }));
-    expect(envJs['a']).toEqual(expect.objectContaining({ values: [true] }));
-    expect(envJs['b']).toEqual(expect.objectContaining({ values: [false] }));
+    expect(envJs.names).toEqual(['.c', 'a', 'b']);
+    expect(envJs.values[0]).toEqual(expect.objectContaining({ names: null, values: [null] }));
+    expect(envJs.values[1]).toEqual(expect.objectContaining({ names: null, values: [true] }));
+    expect(envJs.values[2]).toEqual(expect.objectContaining({ names: null, values: [false] }));
+    const envObj = await env.toObject();
+    expect(envObj['.c']).toEqual(expect.objectContaining({ names: null, values: [null] }));
+    expect(envObj['a']).toEqual(expect.objectContaining({ names: null, values: [true] }));
+    expect(envObj['b']).toEqual(expect.objectContaining({ names: null, values: [false] }));
   });
 
   test('Evaluating R code in an environment', async () => {
@@ -340,19 +365,19 @@ describe('Invoking RFunction objects', () => {
   test('Pass JS booleans as R logical arguments', async () => {
     const c = (await webR.evalRCode('c')).result as RFunction;
     const logical = (await c.exec(true, [true, false])) as RLogical;
-    expect(Array.from(await logical.toArray())).toStrictEqual([true, true, false]);
+    expect(await logical.toArray()).toEqual([true, true, false]);
   });
 
   test('Pass JS number as R double arguments', async () => {
     const c = (await webR.evalRCode('c')).result as RFunction;
     const double = (await c.exec(3.0, [3.1, 3.14])) as RDouble;
-    expect(Array.from(await double.toArray())).toStrictEqual([3.0, 3.1, 3.14]);
+    expect(await double.toArray()).toEqual([3.0, 3.1, 3.14]);
   });
 
   test('Pass JS object as R complex arguments', async () => {
     const c = (await webR.evalRCode('c')).result as RFunction;
     const cmplx = (await c.exec({ re: 1, im: 2 }, { re: -3, im: -4 })) as RComplex;
-    expect(Array.from(await cmplx.toArray())).toEqual([
+    expect(await cmplx.toArray()).toEqual([
       { re: 1, im: 2 },
       { re: -3, im: -4 },
     ]);
@@ -361,7 +386,7 @@ describe('Invoking RFunction objects', () => {
   test('Pass JS string as R character arguments', async () => {
     const c = (await webR.evalRCode('c')).result as RFunction;
     const cmplx = (await c.exec('Hello', ['World', '!'])) as RComplex;
-    expect(Array.from(await cmplx.toArray())).toEqual(['Hello', 'World', '!']);
+    expect(await cmplx.toArray()).toEqual(['Hello', 'World', '!']);
   });
 });
 

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -1,6 +1,6 @@
 import { WebR } from '../../webR/webr-main';
 import { Message } from '../../webR/chan/message';
-import { RDouble } from '../../webR/robj';
+import { NamedArray, RawType, RDouble } from '../../webR/robj';
 
 const webR = new WebR({
   WEBR_URL: '../dist/',
@@ -56,9 +56,9 @@ describe('Evaluate R code', () => {
 
   test('Handle syntax errors in evalRCode', async () => {
     const badSyntax = await webR.evalRCode('42+');
-    const cond = badSyntax.output[0] as { type: string; data: { message: string[] } };
-    expect(cond.type).toEqual('error');
-    expect(cond.data.message).toEqual(expect.stringContaining('unexpected end of input'));
+    const cond = badSyntax.output as { type: string; data: NamedArray<RawType> }[];
+    expect(cond[0].type).toEqual('error');
+    expect(cond[0].data[0].message).toEqual(expect.stringContaining('unexpected end of input'));
   });
 
   test('Write to stdout while evaluating R code', async () => {
@@ -100,9 +100,9 @@ describe('Evaluate R code', () => {
     const res = await webR.evalRCode('warning("This is a warning message")', undefined, {
       captureConditions: true,
     });
-    const cond = res.output[0] as { type: string; data: { message: string[] } };
-    expect(cond.type).toEqual('warning');
-    expect(cond.data.message).toEqual('This is a warning message');
+    const cond = res.output as { type: string; data: NamedArray<RawType> }[];
+    expect(cond[0].type).toEqual('warning');
+    expect(cond[0].data[0].message).toEqual('This is a warning message');
   });
 });
 

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -1,6 +1,6 @@
 import { WebR } from '../../webR/webr-main';
 import { Message } from '../../webR/chan/message';
-import { NamedArrays, RawType, RDouble } from '../../webR/robj';
+import { RObjectTree, RawType, RDouble } from '../../webR/robj';
 
 const webR = new WebR({
   WEBR_URL: '../dist/',
@@ -56,7 +56,7 @@ describe('Evaluate R code', () => {
 
   test('Handle syntax errors in evalRCode', async () => {
     const badSyntax = await webR.evalRCode('42+');
-    const cond = badSyntax.output as { type: string; data: NamedArrays<RawType[]> }[];
+    const cond = badSyntax.output as { type: string; data: RObjectTree<RawType[]> }[];
     expect(cond[0].type).toEqual('error');
     expect(cond[0].data.names).toEqual(expect.arrayContaining(['message']));
     expect(cond[0].data.values[0]).toEqual(expect.stringContaining('unexpected end of input'));
@@ -101,7 +101,7 @@ describe('Evaluate R code', () => {
     const res = await webR.evalRCode('warning("This is a warning message")', undefined, {
       captureConditions: true,
     });
-    const cond = res.output as { type: string; data: NamedArrays<RawType[]> }[];
+    const cond = res.output as { type: string; data: RObjectTree<RawType[]> }[];
     expect(cond[0].type).toEqual('warning');
     expect(cond[0].data.names).toEqual(expect.arrayContaining(['message']));
     expect(cond[0].data.values).toEqual(expect.arrayContaining(['This is a warning message']));

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -1,6 +1,6 @@
 import { WebR } from '../../webR/webr-main';
 import { Message } from '../../webR/chan/message';
-import { NamedArray, RawType, RDouble } from '../../webR/robj';
+import { NamedArrays, RawType, RDouble } from '../../webR/robj';
 
 const webR = new WebR({
   WEBR_URL: '../dist/',
@@ -56,9 +56,10 @@ describe('Evaluate R code', () => {
 
   test('Handle syntax errors in evalRCode', async () => {
     const badSyntax = await webR.evalRCode('42+');
-    const cond = badSyntax.output as { type: string; data: NamedArray<RawType> }[];
+    const cond = badSyntax.output as { type: string; data: NamedArrays<RawType[]> }[];
     expect(cond[0].type).toEqual('error');
-    expect(cond[0].data[0].message).toEqual(expect.stringContaining('unexpected end of input'));
+    expect(cond[0].data.names).toEqual(expect.arrayContaining(['message']));
+    expect(cond[0].data.values[0]).toEqual(expect.stringContaining('unexpected end of input'));
   });
 
   test('Write to stdout while evaluating R code', async () => {
@@ -100,9 +101,10 @@ describe('Evaluate R code', () => {
     const res = await webR.evalRCode('warning("This is a warning message")', undefined, {
       captureConditions: true,
     });
-    const cond = res.output as { type: string; data: NamedArray<RawType> }[];
+    const cond = res.output as { type: string; data: NamedArrays<RawType[]> }[];
     expect(cond[0].type).toEqual('warning');
-    expect(cond[0].data[0].message).toEqual('This is a warning message');
+    expect(cond[0].data.names).toEqual(expect.arrayContaining(['message']));
+    expect(cond[0].data.values).toEqual(expect.arrayContaining(['This is a warning message']));
   });
 });
 

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -428,7 +428,7 @@ export class RObjSymbol extends RObjImpl {
 
 export type NamedEntries<T> = [string | number, T][];
 export type NamedArrays<T> = {
-  names?: (string | number | undefined)[];
+  names?: (string | undefined)[];
   values: T;
   missing?: boolean[];
 };
@@ -443,7 +443,7 @@ export class RObjPairlist extends RObjImpl {
     return this.toArrays().values;
   }
 
-  toObject({ throwOnDuplicateKey = false } = {}): { [key: string]: RawType } {
+  toObject({ throwOnDuplicateKey = false } = {}): NamedObject<RawType> {
     const entries = this.entries();
     const keys = entries.map(([k, v]) => k);
     if (throwOnDuplicateKey && new Set(keys).size !== keys.length) {
@@ -463,7 +463,7 @@ export class RObjPairlist extends RObjImpl {
   }
 
   toArrays(): NamedArrays<RawType[]> {
-    const names: (string | number | undefined)[] = [];
+    const names: (string | undefined)[] = [];
     const values: RawType[] = [];
     for (let next = this as Nullable<RObjPairlist>; !next.isNull(); next = next.cdr()) {
       const symbol = next.tag();
@@ -595,7 +595,7 @@ export class RObjEnvironment extends RObjImpl {
     return this.getDollar(prop);
   }
 
-  toObject(): { [key: string | number]: RawType } {
+  toObject(): NamedObject<RawType> {
     const symbols = this.names();
     return Object.fromEntries(
       [...Array(symbols.length).keys()].map((i) => {

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -745,6 +745,11 @@ export class RObjInteger extends RObjAtomicVector {
       )
     );
   }
+
+  toArray(): number[] {
+    const arr = this.toTypedArray();
+    return this.missing().map((m, idx) => (m ? NaN : arr[idx]));
+  }
 }
 
 export class RObjDouble extends RObjAtomicVector {

--- a/src/webR/utils.ts
+++ b/src/webR/utils.ts
@@ -1,4 +1,4 @@
-import { RawType, NamedArrays, NamedObject } from './robj';
+import { RawType, RObjectTree, NamedObject } from './robj';
 
 export type ResolveFn = (_value?: unknown) => void;
 export type RejectFn = (_reason?: any) => void;
@@ -40,7 +40,7 @@ export function unpackScalarVectors(obj: RawType): RawType {
   );
 }
 
-export function mergeListArrays(obj: NamedArrays<RawType[]>): NamedObject<RawType> {
+export function mergeListArrays(obj: RObjectTree<RawType[]>): NamedObject<RawType> {
   const names = obj.names as string[];
   if (!names || names.some((name) => typeof name === 'undefined')) {
     throw new Error('Attempted to merge unnamed list array');

--- a/src/webR/utils.ts
+++ b/src/webR/utils.ts
@@ -1,4 +1,4 @@
-import { RawType } from './robj';
+import { NamedArray, NamedObject, RawType } from './robj';
 
 export type ResolveFn = (_value?: unknown) => void;
 export type RejectFn = (_reason?: any) => void;
@@ -37,4 +37,8 @@ export function unpackScalarArrays(obj: RawType): RawType {
   return Object.fromEntries(
     Object.entries(obj).map(([k, v]: [string, RawType]) => [k, unpackScalarArrays(v)])
   );
+}
+
+export function mergeListObjects(obj: NamedArray<RawType>): NamedObject<RawType> {
+  return obj.reduce((prev, cur) => Object.assign(prev, cur), {});
 }

--- a/src/webR/utils.ts
+++ b/src/webR/utils.ts
@@ -24,17 +24,20 @@ export function sleep(ms: number) {
 }
 
 export function unpackScalarVectors(obj: RawType): RawType {
-  if (obj === null || typeof obj !== 'object' || !('values' in obj)) {
+  if (obj === null || typeof obj !== 'object') {
     return obj;
   }
-  if (Array.isArray(obj.values)) {
+  if ('values' in obj && Array.isArray(obj.values)) {
     if (obj.values.length === 1) {
       obj = unpackScalarVectors(obj.values[0]);
     } else {
       obj.values = obj.values.map((v: RawType) => unpackScalarVectors(v));
     }
+    return obj;
   }
-  return obj;
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]: [string, RawType]) => [k, unpackScalarVectors(v)])
+  );
 }
 
 export function mergeListArrays(obj: NamedArrays<RawType[]>): NamedObject<RawType> {

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -2,8 +2,8 @@ import { ChannelMain } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy } from './proxy';
-import { unpackScalarArrays } from './utils';
-import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList } from './robj';
+import { unpackScalarArrays, mergeListObjects } from './utils';
+import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList, NamedArray } from './robj';
 
 export type EvalRCodeOptions = {
   captureStreams?: boolean;
@@ -128,7 +128,9 @@ export class WebR {
         obj.preserve();
         const result = await obj.get(1);
         const outList = (await obj.get(2)) as RList;
-        const output = (await outList.toArray()).map((v) => unpackScalarArrays(v));
+        const output = (await outList.values()).map((v) =>
+          mergeListObjects(unpackScalarArrays(v) as NamedArray<RawType>)
+        );
         obj.release();
         return { result, output };
       }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -3,7 +3,7 @@ import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy } from './proxy';
 import { unpackScalarVectors, mergeListArrays } from './utils';
-import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList, NamedArrays } from './robj';
+import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList, RObjectTree } from './robj';
 
 export type EvalRCodeOptions = {
   captureStreams?: boolean;
@@ -129,7 +129,7 @@ export class WebR {
         const result = await obj.get(1);
         const outList = (await obj.get(2)) as RList;
         const output = (await outList.toArray())
-          .map((v) => unpackScalarVectors(v) as NamedArrays<RawType[]>)
+          .map((v) => unpackScalarVectors(v) as RObjectTree<RawType[]>)
           .map((v) => mergeListArrays(v));
         obj.release();
         return { result, output };

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -2,8 +2,8 @@ import { ChannelMain } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy } from './proxy';
-import { unpackScalarArrays, mergeListObjects } from './utils';
-import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList, NamedArray } from './robj';
+import { unpackScalarVectors, mergeListArrays } from './utils';
+import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList, NamedArrays } from './robj';
 
 export type EvalRCodeOptions = {
   captureStreams?: boolean;
@@ -128,9 +128,9 @@ export class WebR {
         obj.preserve();
         const result = await obj.get(1);
         const outList = (await obj.get(2)) as RList;
-        const output = (await outList.values()).map((v) =>
-          mergeListObjects(unpackScalarArrays(v) as NamedArray<RawType>)
-        );
+        const output = (await outList.toArray())
+          .map((v) => unpackScalarVectors(v) as NamedArrays<RawType[]>)
+          .map((v) => mergeListArrays(v));
         obj.release();
         return { result, output };
       }


### PR DESCRIPTION
Contains #62.

R lists and pairlists are changed so that the default structure when converting from an R object to a JS object is an array of objects, rather than simply a JS object. For example, `list(a=1,b=2,c=3)` becomes `[{ a: [1] }, { b: [2] }, { c: [3] }]`.

This structure better reflects the flexibility of R lists. Lists containing objects with repeated names or some non-named objects work better in the new default structure, and the order of objects is preserved.

For both types of list, the method `toJs()` now invokes `toArray()` which returns objects in the new structure. What was previously `toArray()` is now named `values()` to match JS's `Object.values`, which has a similar behaviour.

The current behaviour of `toJs()` on lists can be obtained by explicitly invoking the `toObject()` method.