### PR TITLE
Switch from jquery terminal to xterm.js with xterm-readline

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -816,11 +816,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@jcubic/lily": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@jcubic/lily/-/lily-0.3.0.tgz",
-      "integrity": "sha512-4z6p4jLGSthc8gQ7wu4nHfGYn/IgCKFr+7hjuf80VdXUs7sm029mZGGDpS8sb29PVZWUBvMMTBCVGFhH2nN4Vw=="
-    },
     "@jest/console": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz",
@@ -1355,6 +1350,7 @@
       "version": "3.5.14",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
       "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dev": true,
       "requires": {
         "@types/sizzle": "*"
       }
@@ -1401,7 +1397,8 @@
     "@types/sizzle": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -1647,8 +1644,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -1658,11 +1654,6 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
-    },
-    "ansidec": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/ansidec/-/ansidec-0.3.4.tgz",
-      "integrity": "sha512-Ydgbey4zqUmmNN2i2OVeVHXig3PxHRbok2X6B2Sogmb92JzZUFfTL806dT7os6tBL1peXItfeFt76CP3zsoXUg=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -2045,11 +2036,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -2210,14 +2196,6 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "requires": {
-        "clone": "^1.0.2"
-      }
-    },
     "defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
@@ -2296,8 +2274,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -2991,6 +2968,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -3578,8 +3556,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -4307,31 +4284,6 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
-    "jquery.terminal": {
-      "version": "2.33.3",
-      "resolved": "https://registry.npmjs.org/jquery.terminal/-/jquery.terminal-2.33.3.tgz",
-      "integrity": "sha512-FlqCWmMaygQZ1BbX3TswsMWH1Zh11o0s9brGG3Kwsc+Hav4KxrHyiZF7QJ2kE48DqTxb6fpdRn9g7olqp1XosQ==",
-      "requires": {
-        "@jcubic/lily": "^0.3.0",
-        "@types/jquery": "^3.5.14",
-        "ansidec": "^0.3.4",
-        "fsevents": "^2.3.2",
-        "iconv-lite": "^0.6.3",
-        "jquery": "^3.6.0",
-        "prismjs": "^1.27.0",
-        "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5011,11 +4963,6 @@
         }
       }
     },
-    "prismjs": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
-      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -5317,7 +5264,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "7.3.7",
@@ -5486,7 +5434,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5497,7 +5444,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -5871,14 +5817,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "requires": {
-        "defaults": "^1.0.3"
-      }
-    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5941,6 +5879,24 @@
     "xmlhttprequest": {
       "version": "git+https://github.com/georgestagg/node-XMLHttpRequest.git#d251dae286eca9eada9133fff9bdbaeb91ac22f9",
       "from": "git+https://github.com/georgestagg/node-XMLHttpRequest.git#response-buffer"
+    },
+    "xterm": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.19.0.tgz",
+      "integrity": "sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ=="
+    },
+    "xterm-addon-fit": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
+      "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ=="
+    },
+    "xterm-readline": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/xterm-readline/-/xterm-readline-1.0.7.tgz",
+      "integrity": "sha512-XnZ9+80PF1+GZr9mtI7mO97JnDo0KEMe1vrOodD23OUpceuhJGDF8/S2cBhnmiLFw+ihnUpBWjEMUw/N5lsdnw==",
+      "requires": {
+        "string-width": "^4.0.0"
+      }
     },
     "y18n": {
       "version": "5.0.8",

--- a/src/package.json
+++ b/src/package.json
@@ -5,9 +5,11 @@
   "dependencies": {
     "@types/emscripten": "^1.39.6",
     "jquery": "^3.6.0",
-    "jquery.terminal": "^2.33.3",
     "jstree": "^3.3.12",
-    "xmlhttprequest": "git+https://github.com/georgestagg/node-XMLHttpRequest.git#response-buffer"
+    "xmlhttprequest": "git+https://github.com/georgestagg/node-XMLHttpRequest.git#response-buffer",
+    "xterm": "^4.19.0",
+    "xterm-addon-fit": "^0.5.0",
+    "xterm-readline": "^1.0.7"
   },
   "devDependencies": {
     "@types/jest": "^28.1.8",

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -17,13 +17,21 @@ const fitAddon = new FitAddon();
 const readline = new Readline();
 
 term.write('webR is downloading, please wait...');
-
 term.loadAddon(fitAddon);
 term.loadAddon(readline);
 term.open(document.getElementById('term') as HTMLElement);
-fitAddon.fit();
-window.addEventListener('resize', () => fitAddon.fit());
 term.focus();
+fitAddon.fit();
+
+function resizeTerm() {
+  (async () => {
+    await webR.init();
+    const dims = fitAddon.proposeDimensions();
+    webR.evalRCode(`options(width=${dims ? dims.cols : 80})`);
+  })();
+  fitAddon.fit();
+}
+window.addEventListener('resize', resizeTerm);
 
 let FSTree: FSTreeInterface;
 
@@ -73,6 +81,7 @@ const webR = new WebR({
 
   // Clear the loading message
   term.write('\x1b[2K\r');
+  resizeTerm();
 
   FSTree = initFSTree({
     selector: '#jstree_fs',

--- a/src/templates/repl.html
+++ b/src/templates/repl.html
@@ -56,6 +56,7 @@
             position: relative;
             width: 50vw;
             height: 100vh;
+            background-color: #191919;
         }
         #plot {
             background-color: #727272;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,7 +9,7 @@
     "noUnusedLocals": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node", "emscripten", "jquery", "jquery.terminal", "jstree", "jest"],
+    "types": ["node", "emscripten", "jquery", "xterm", "jstree", "jest"],
     "noEmit": true,
   },
   "include": ["**/*.ts"],


### PR DESCRIPTION
Includes #62.

This should provide improved performance. I'll do some basic measurements and add them here soon.

EDIT:
Time taken to print n elements of random `rnorm` output at 80 characters per line:
| n | jquery.terminal (ms) | xterm.js (ms)
|---|---|---|
| 100   | 24 | 12 |
| 1000   | 92 | 143 |
| 10000  | 1932 | 350 |
| 100000  | 318771 | 2171 |
| 1000000  | ? | 20963 |