### PR TITLE
Switch to the latest version of xmlhttprequest-ssl

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -5938,9 +5938,10 @@
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
-    "xmlhttprequest": {
-      "version": "git+https://github.com/georgestagg/node-XMLHttpRequest.git#d251dae286eca9eada9133fff9bdbaeb91ac22f9",
-      "from": "git+https://github.com/georgestagg/node-XMLHttpRequest.git#response-buffer"
+    "xmlhttprequest-ssl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.0.tgz",
+      "integrity": "sha512-PlkG6ZrKEtYVRDboRw5uUzy3nc6vMrZyT94Z3MzLc0PvFzy6d6VD8OLKKcsk9GdQDxz0XQjIwNHvpIMC/1v0pA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,7 @@
     "jquery": "^3.6.0",
     "jquery.terminal": "^2.33.3",
     "jstree": "^3.3.12",
-    "xmlhttprequest": "git+https://github.com/georgestagg/node-XMLHttpRequest.git#response-buffer"
+    "xmlhttprequest-ssl": "^2.1.0"
   },
   "devDependencies": {
     "@types/jest": "^28.1.8",


### PR DESCRIPTION
A PR for xmlhttprequest-ssl fixing the binary data issue ([#11](https://github.com/mjwwit/node-XMLHttpRequest/pull/11)) has been accepted and a new package published to npm. As such, use of my temporary fork has been removed.