### PR TITLE
Implement iterators for proxies of R objects that have a `length`

### DIFF
--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -49,6 +49,7 @@ type RProxify<T> = T extends RObjImpl
  */
 export type RProxy<T extends RObjImpl> = { [P in Methods<T>]: RProxify<T[P]> } & {
   _target: RTargetObj;
+  [Symbol.asyncIterator](): AsyncGenerator<RProxy<RObjImpl>, void, unknown>;
 };
 
 /* The empty function is used as base when we are proxying RFunction objects.
@@ -56,46 +57,86 @@ export type RProxy<T extends RObjImpl> = { [P in Methods<T>]: RProxify<T[P]> } &
  */
 function empty() {}
 
-export function newRProxy(chan: ChannelMain, target: RTargetPtr): RProxy<RObjImpl> {
-  // Assume we are proxying an RFunction if the methods list contains 'exec'.
-  return new Proxy(target.methods.includes('exec') ? Object.assign(empty, { ...target }) : target, {
-    get: (_: RTargetObj, prop: string | number | symbol) => {
-      if (prop === '_target') {
-        return target;
-      } else if (target.methods.includes(prop.toString())) {
-        return async (...args: unknown[]) => {
-          const argTargets = Array.from({ length: args.length }, (_, idx) => {
-            const arg = args[idx];
-            return isRObject(arg) ? arg._target : { obj: arg, type: RTargetType.RAW };
-          });
+/* Proxy the asyncIterator property for R objects with a length. This allows us
+ * to use the `for await (i of obj){}` JavaScript syntax.
+ */
+function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RObjImpl>) {
+  return async function* () {
+    // Get the R object's length
+    const reply = (await chan.request({
+      type: 'getRObjProperty',
+      data: {
+        target: proxy._target,
+        prop: 'length',
+      },
+    })) as RTargetObj;
 
-          const reply = (await chan.request({
-            type: 'callRObjMethod',
-            data: {
-              target: target,
-              prop: prop.toString(),
-              args: argTargets,
-            },
-          })) as RTargetObj;
+    // Throw an error if there was some problem accessing the object length
+    if (reply.type === RTargetType.ERR) {
+      const e = new Error(`Cannot iterate over object, ${reply.obj.message}`);
+      e.name = reply.obj.name;
+      e.stack = reply.obj.stack;
+      throw e;
+    } else if (typeof reply.obj !== 'number') {
+      throw new Error('Cannot iterate over object, unexpected type for length property.');
+    }
 
-          switch (reply.type) {
-            case RTargetType.PTR:
-              return newRProxy(chan, reply);
-            case RTargetType.ERR: {
-              const e = new Error(reply.obj.message);
-              e.name = reply.obj.name;
-              e.stack = reply.obj.stack;
-              throw e;
-            }
-            default:
-              return reply.obj;
-          }
-        };
+    // Loop through the object and yield values
+    for (let i = 1; i <= reply.obj; i++) {
+      yield proxy.get(i);
+    }
+  };
+}
+
+/* Proxy an R object method by providing an async function that requests that
+ * the worker thread calls the method and then returns the result.
+ */
+function targetMethod(chan: ChannelMain, target: RTargetPtr, prop: string) {
+  return async (..._args: unknown[]) => {
+    const args = Array.from({ length: _args.length }, (_, idx) => {
+      const arg = _args[idx];
+      return isRObject(arg) ? arg._target : { obj: arg, type: RTargetType.RAW };
+    });
+
+    const reply = (await chan.request({
+      type: 'callRObjMethod',
+      data: { target, prop, args },
+    })) as RTargetObj;
+
+    switch (reply.type) {
+      case RTargetType.PTR:
+        return newRProxy(chan, reply);
+      case RTargetType.ERR: {
+        const e = new Error(reply.obj.message);
+        e.name = reply.obj.name;
+        e.stack = reply.obj.stack;
+        throw e;
       }
-    },
-    apply: async (_: RTargetObj, _thisArg, args: (RawType | RProxy<RObjImpl>)[]) => {
-      const res = await (newRProxy(chan, target) as RProxy<RObjFunction>).exec(...args);
-      return isRFunction(res) ? res : res.toJs();
-    },
-  }) as unknown as RProxy<RObjImpl>;
+      default:
+        return reply.obj;
+    }
+  };
+}
+
+export function newRProxy(chan: ChannelMain, target: RTargetPtr): RProxy<RObjImpl> {
+  const proxy = new Proxy(
+    // Assume we are proxying an RFunction if the methods list contains 'exec'.
+    target.methods.includes('exec') ? Object.assign(empty, { ...target }) : target,
+    {
+      get: (_: RTargetObj, prop: string | number | symbol) => {
+        if (prop === '_target') {
+          return target;
+        } else if (prop === Symbol.asyncIterator) {
+          return targetAsyncIterator(chan, proxy);
+        } else if (target.methods.includes(prop.toString())) {
+          return targetMethod(chan, target, prop.toString());
+        }
+      },
+      apply: async (_: RTargetObj, _thisArg, args: (RawType | RProxy<RObjImpl>)[]) => {
+        const res = await (newRProxy(chan, target) as RProxy<RObjFunction>).exec(...args);
+        return isRFunction(res) ? res : res.toJs();
+      },
+    }
+  ) as unknown as RProxy<RObjImpl>;
+  return proxy;
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -2,8 +2,8 @@ import { newChannelMain, ChannelMain } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy } from './proxy';
-import { unpackScalarVectors, mergeListArrays } from './utils';
-import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList, RObjectTree } from './robj';
+import { unpackScalarVectors } from './utils';
+import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList } from './robj';
 
 export type EvalRCodeOptions = {
   captureStreams?: boolean;
@@ -132,9 +132,11 @@ export class WebR {
         obj.preserve();
         const result = await obj.get(1);
         const outList = (await obj.get(2)) as RList;
-        const output = (await outList.toArray())
-          .map((v) => unpackScalarVectors(v) as RObjectTree<RawType[]>)
-          .map((v) => mergeListArrays(v));
+        const output: RawType[] = [];
+        for await (const out of outList) {
+          const obj = await (out as RList).toObject();
+          output.push(unpackScalarVectors(obj));
+        }
         obj.release();
         return { result, output };
       }


### PR DESCRIPTION
Includes #67.

Implements `Symbol.asyncIterator` on the R object proxy. This enables use of the following kind of syntax to loop over elements of R objects from the main thread.

```
for await (i of obj){
  console.log(await i.toJs())
}
```

The new support is used in `webr-main.ts` to loop over some output objects in `evalRCode`, facilitating the removal of an extra function in `utils.ts` mutating the result of `toJs()` in an unsatisfying way.