### PR TITLE
Enable interruption of long running R computations

### DIFF
--- a/patches/R-4.1.3/emscripten-input.diff
+++ b/patches/R-4.1.3/emscripten-input.diff
@@ -29,17 +29,33 @@ Index: R-4.1.3/src/unix/sys-std.c
  #endif
  
  extern SA_TYPE SaveAction;
-@@ -949,6 +950,9 @@ handleInterrupt(void)
- }
- #endif /* HAVE_LIBREADLINE */
+@@ -325,8 +326,17 @@ getInputHandler(InputHandler *handlers, 
+ 
+ static void nop(void){}
  
 +#ifdef __EMSCRIPTEN__
 +#include <emscripten.h>
++static void handleEvents(void){
++	EM_ASM(globalThis.Module.webr.handleEvents());
++}
++void (* R_PolledEvents)(void) = handleEvents;
++int R_wait_usec = 100000;
++#else
+ void (* R_PolledEvents)(void) = nop;
+ int R_wait_usec = 0; /* 0 means no timeout */
 +#endif
  
+ /* For X11 devices */
+ void (* Rg_PolledEvents)(void) = nop;
+@@ -949,7 +959,6 @@ handleInterrupt(void)
+ }
+ #endif /* HAVE_LIBREADLINE */
+ 
+-
  /* Fill a text buffer from stdin or with user typed console input. */
  static void *cd = NULL;
-@@ -1030,8 +1034,12 @@ Rstd_ReadConsole(const char *prompt, uns
+ 
+@@ -1030,8 +1039,12 @@ Rstd_ReadConsole(const char *prompt, uns
  	else
  #endif /* HAVE_LIBREADLINE */
  	{
@@ -52,7 +68,7 @@ Index: R-4.1.3/src/unix/sys-std.c
  	}
  
  	if(R_InputHandlers == NULL)
-@@ -1089,10 +1097,24 @@ Rstd_ReadConsole(const char *prompt, uns
+@@ -1089,10 +1102,24 @@ Rstd_ReadConsole(const char *prompt, uns
  		else
  #endif /* HAVE_LIBREADLINE */
  		{

--- a/src/console/console.ts
+++ b/src/console/console.ts
@@ -21,6 +21,9 @@ export interface ConsoleCallbacks {
  * R code can be sent as input by calling the ``stdin`` method with a single
  * line of textual input.
  *
+ * A long running R computation can be interrupted by calling the `interrupt`
+ * method.
+ *
  * The ``prompt`` callback function is called when webR produces a prompt at
  * the REPL console and is therefore awaiting user input. The prompt character
  * (usually ``>`` or ``+``) is given as the first argument to the callback
@@ -86,6 +89,13 @@ export class Console {
    */
   stdin(input: string) {
     this.webR.writeConsole(input + '\n');
+  }
+
+  /**
+   * Interrupt a long running R computation and return to the prompt
+   */
+  interrupt() {
+    this.webR.interrupt();
   }
 
   /**

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -76,6 +76,8 @@ const webR = new WebR({
 (async () => {
   await webR.init();
 
+  readline.setCtrlCHandler(() => webR.interrupt());
+
   webR.evalRCode(`options(webr_pkg_repos="${PKG_BASE_URL}")`);
   webR.evalRCode('webr::global_prompt_install()', undefined, { withHandlers: false });
 

--- a/src/tests/console/console.test.ts
+++ b/src/tests/console/console.test.ts
@@ -38,6 +38,15 @@ test('Generate an error message and write to stdout', async () => {
   expect(stderr).toHaveBeenCalledWith('Error: unexpected \';\' in ";"');
 });
 
+test('Interrupt a long running R computation', async () => {
+  waitForPrompt = promiseHandles();
+  con.stdin('while(TRUE){}');
+  con.interrupt();
+  // A new prompt will appear only if the infinite loop is successfully interrupted
+  await waitForPrompt.promise;
+  expect(prompt).toHaveBeenCalledWith('> ');
+});
+
 afterAll(() => {
   return con.webR.close();
 });

--- a/src/webR/chan/task-worker.ts
+++ b/src/webR/chan/task-worker.ts
@@ -222,7 +222,7 @@ function releaseDataBuffer(buffer: Uint8Array) {
 
 export const interruptBuffer = new Int32Array(new SharedArrayBuffer(4));
 
-let handleInterrupt = () => {
+let handleInterrupt = (): void => {
   interruptBuffer[0] = 0;
   throw new Error('Interrupted!');
 };
@@ -233,6 +233,6 @@ let handleInterrupt = () => {
  * @function handler
  * @param {handler} handler
  */
-export function setInterruptHandler(handler: () => never) {
+export function setInterruptHandler(handler: () => void) {
   handleInterrupt = handler;
 }

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -76,6 +76,7 @@ export interface Module extends EmscriptenModule {
   _Rf_lang6: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr, ptr4: RPtr, ptr5: RPtr, ptr6: RPtr) => RPtr;
   _Rf_mkChar: (ptr: number) => RPtr;
   _Rf_mkString: (ptr: number) => RPtr;
+  _Rf_onintr: () => RPtr;
   _Rf_protect: (ptr: RPtr) => RPtr;
   _Rf_unprotect: (n: number) => void;
   _Rf_unprotect_ptr: (ptr: RPtr) => void;

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -96,5 +96,6 @@ export interface Module extends EmscriptenModule {
   webr: {
     readConsole: () => number;
     resolveInit: () => void;
+    handleEvents: () => void;
   };
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -77,7 +77,7 @@ export class WebR {
   }
 
   interrupt() {
-    this.#chan.userBreakSignal = 1;
+    this.#chan.interrupt();
   }
 
   async installPackages(packages: string[]) {

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -76,6 +76,10 @@ export class WebR {
     this.write({ type: 'stdin', data: input + '\n' });
   }
 
+  interrupt() {
+    this.#chan.userBreakSignal = 1;
+  }
+
   async installPackages(packages: string[]) {
     for (const pkg of packages) {
       const msg = { type: 'installPackage', data: { name: pkg } };

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -339,6 +339,10 @@ function init(config: Required<WebROptions>) {
       const input = inputOrDispatch(chan);
       return Module.allocateUTF8(input);
     },
+
+    handleEvents: () => {
+      }
+    },
   };
 
   Module.locateFile = (path: string) => _config.WEBR_URL + path;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -341,6 +341,8 @@ function init(config: Required<WebROptions>) {
     },
 
     handleEvents: () => {
+      if (chan.userBreakSignal()) {
+        Module._Rf_onintr();
       }
     },
   };


### PR DESCRIPTION
R will periodically call `R_PolledEvents` during long running computations. A handler is installed there to manage events from webR.

A `SyncTask` of type `userBreakSignal` is setup to check for interrupts as part of the event handling. If the user has signalled an interrupt by invoking `webR.interrupt()` (also hooked up to `Ctrl-C` in the REPL app), R's `onintr()` is invoked which breaks execution and returns to the prompt.

