### PR TITLE
Add depth parameter to `toTree`, `toArray`, `toObject` on R lists, pairlists and environments

### DIFF
--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -1,4 +1,4 @@
-import { RTargetType, RTargetPtr, isRObject, RTargetObj } from './robj';
+import { RTargetType, RTargetPtr, isRObject, RTargetObj, RObjectTree, RObject } from './robj';
 import { RObjImpl, RObjFunction, RawType, isRFunction, isRTargetPtr } from './robj';
 import { ChannelMain } from './chan/channel';
 import { replaceInObject } from './utils';
@@ -13,7 +13,11 @@ type Methods<T> = {
  *
  * Distributes RProxy over any RObjImpls in the given union type U.
  */
-type DistProxy<U> = U extends RObjImpl ? RProxy<U> : U;
+type DistProxy<U> = U extends RObjImpl
+  ? RProxy<U>
+  : U extends RObjectTree<RObjImpl>
+  ? RObjectTree<RObject>
+  : U;
 
 /** Convert an RObjImpl property type to a corresponding RProxy property type
  *

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -1,6 +1,7 @@
 import { RTargetType, RTargetPtr, isRObject, RTargetObj } from './robj';
-import { RObjImpl, RObjFunction, RawType, isRFunction } from './robj';
+import { RObjImpl, RObjFunction, RawType, isRFunction, isRTargetPtr } from './robj';
 import { ChannelMain } from './chan/channel';
+import { replaceInObject } from './utils';
 
 /** Obtain a union of the keys corresponding to methods of a given class T
  */
@@ -25,15 +26,15 @@ type DistProxy<U> = U extends RObjImpl ? RProxy<U> : U;
  *
  * Any other types are wrapped in a Promise.
  */
-type RProxify<T> = T extends RObjImpl
-  ? Promise<RProxy<T>>
+type RProxify<T> = T extends Array<any>
+  ? Promise<DistProxy<T[0]>[]>
   : T extends (...args: infer U) => any
   ? (
       ...args: {
         [V in keyof U]: DistProxy<U[V]>;
       }
     ) => RProxify<ReturnType<T>>
-  : Promise<T>;
+  : Promise<DistProxy<T>>;
 
 /** Create an RProxy type based on an RObjImpl type parameter
  *
@@ -112,8 +113,15 @@ function targetMethod(chan: ChannelMain, target: RTargetPtr, prop: string) {
         e.stack = reply.obj.stack;
         throw e;
       }
-      default:
-        return reply.obj;
+      default: {
+        const proxyReply = replaceInObject(
+          reply,
+          isRTargetPtr,
+          (obj: RTargetPtr, chan: ChannelMain) => newRProxy(chan, obj),
+          chan
+        ) as RTargetObj;
+        return proxyReply.obj;
+      }
     }
   };
 }

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -882,6 +882,23 @@ export function isRObject(value: any): value is RObject {
 }
 
 /**
+ * Test for an RTargetPtr instance
+ *
+ * @param {any} value The object to test.
+ * @return {boolean} True if the object is an instance of an RTargetPtr.
+ */
+export function isRTargetPtr(value: any): value is RTargetPtr {
+  return (
+    value &&
+    typeof value === 'object' &&
+    'type' in value &&
+    'obj' in value &&
+    'methods' in value &&
+    value.type === 'PTR'
+  );
+}
+
+/**
  * Test for an RFunction instance
  *
  * @param {any} value The object to test.

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -106,6 +106,7 @@ export type RawType =
 export type NamedEntries<T> = [string | null, T][];
 export type NamedObject<T> = { [key: string]: T };
 
+export type RObjData = RObjImpl | RawType | RObjectTree<RObjImpl>;
 export type RObjectTree<T> = RObjectTreeImpl<(RObjectTree<T> | RawType | T)[]>;
 export type RObjectTreeAtomic<T> = RObjectTreeImpl<(T | null)[]>;
 type RObjectTreeImpl<T> = {
@@ -450,13 +451,15 @@ export class RObjPairlist extends RObjImpl {
     return this.toArray().length;
   }
 
-  toArray(options: ToTreeOptions = { depth: 1 }): (RObjImpl | RawType | RObjectTree<RObjImpl>)[] {
+  toArray(options: ToTreeOptions = { depth: 1 }): RObjData[] {
     return this.toTree(options).values;
   }
 
-  toObject({ allowDuplicateKey = true, allowEmptyKey = false, depth = 1 } = {}): NamedObject<
-    RObjImpl | RawType | RObjectTree<RObjImpl>
-  > {
+  toObject({
+    allowDuplicateKey = true,
+    allowEmptyKey = false,
+    depth = 1,
+  } = {}): NamedObject<RObjData> {
     const entries = this.entries({ depth });
     const keys = entries.map(([k, v]) => k);
     if (!allowDuplicateKey && new Set(keys).size !== keys.length) {
@@ -470,9 +473,7 @@ export class RObjPairlist extends RObjImpl {
     );
   }
 
-  entries(
-    options: ToTreeOptions = { depth: 1 }
-  ): NamedEntries<RObjImpl | RawType | RObjectTree<RObjImpl>> {
+  entries(options: ToTreeOptions = { depth: 1 }): NamedEntries<RObjData> {
     const obj = this.toTree(options);
     return obj.values.map((v, i) => [obj.names ? obj.names[i] : null, v]);
   }
@@ -526,15 +527,15 @@ export class RObjList extends RObjImpl {
     return Module._LENGTH(this.ptr);
   }
 
-  toArray(
-    options: { depth: number } = { depth: 1 }
-  ): (RObjImpl | RawType | RObjectTree<RObjImpl>)[] {
+  toArray(options: { depth: number } = { depth: 1 }): RObjData[] {
     return this.toTree(options).values;
   }
 
-  toObject({ allowDuplicateKey = true, allowEmptyKey = false, depth = 1 } = {}): NamedObject<
-    RObjImpl | RawType | RObjectTree<RObjImpl>
-  > {
+  toObject({
+    allowDuplicateKey = true,
+    allowEmptyKey = false,
+    depth = 1,
+  } = {}): NamedObject<RObjData> {
     const entries = this.entries({ depth });
     const keys = entries.map(([k, v]) => k);
     if (!allowDuplicateKey && new Set(keys).size !== keys.length) {
@@ -548,9 +549,7 @@ export class RObjList extends RObjImpl {
     );
   }
 
-  entries(
-    options: { depth: number } = { depth: 1 }
-  ): NamedEntries<RObjImpl | RawType | RObjectTree<RObjImpl>> {
+  entries(options: { depth: number } = { depth: 1 }): NamedEntries<RObjData> {
     const obj = this.toTree(options);
     return obj.values.map((v, i) => [obj.names ? obj.names[i] : null, v]);
   }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -138,7 +138,7 @@ export class WebR {
         const outList = (await obj.get(2)) as RList;
         const output: RawType[] = [];
         for await (const out of outList) {
-          const obj = await (out as RList).toObject();
+          const obj = (await (out as RList).toObject({ depth: 0 })) as RawType;
           output.push(unpackScalarVectors(obj));
         }
         obj.release();

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -2,8 +2,17 @@ import { newChannelMain, ChannelMain, ChannelType } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy } from './proxy';
-import { unpackScalarVectors } from './utils';
-import { RTargetObj, RTargetType, RObject, isRObject, RawType, RList } from './robj';
+import { unpackScalarVectors, replaceInObject } from './utils';
+import {
+  RTargetObj,
+  RTargetType,
+  RObject,
+  isRObject,
+  RawType,
+  RList,
+  RObjectTree,
+  NamedObject,
+} from './robj';
 
 export type EvalRCodeOptions = {
   captureStreams?: boolean;
@@ -147,11 +156,14 @@ export class WebR {
     }
   }
 
-  async newRObject(jsObj: RawType): Promise<RObject> {
+  async newRObject(
+    jsObj: RawType | RawType[] | RObjectTree<RObject> | NamedObject<RawType | RObject>
+  ): Promise<RObject> {
+    const targetObj = replaceInObject(jsObj, isRObject, (obj: RObject) => obj._target);
     const target = (await this.#chan.request({
       type: 'newRObject',
       data: {
-        obj: { type: RTargetType.RAW, obj: jsObj },
+        obj: { type: RTargetType.RAW, obj: targetObj },
       },
     })) as RTargetObj;
     switch (target.type) {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -4,6 +4,7 @@ import { Message, Request, newResponse } from './chan/message';
 import { FSNode, WebROptions, EvalRCodeOptions } from './webr-main';
 import { Module } from './module';
 import { IN_NODE } from './compat';
+import { replaceInObject } from './utils';
 import {
   isRObjImpl,
   RObjImpl,
@@ -235,11 +236,11 @@ function callRObjMethod(obj: RObjImpl, prop: string, args: RTargetObj[]): RTarge
     })
   ) as RawType | RObjImpl;
 
-  if (isRObjImpl(res)) {
-    return { obj: res.ptr, methods: RObjImpl.getMethods(res), type: RTargetType.PTR };
-  } else {
-    return { obj: res, type: RTargetType.RAW };
-  }
+  const ret = replaceInObject(res, isRObjImpl, (obj: RObjImpl) => {
+    return { obj: obj.ptr, methods: RObjImpl.getMethods(obj), type: RTargetType.PTR };
+  }) as RawType;
+
+  return { obj: ret, type: RTargetType.RAW };
 }
 
 /**


### PR DESCRIPTION
The depth parameter controls how deep R objects are converted to JS Objects. 0 means infinite depth. The argument default is set to 0 for `toTree` and 1 for `toArray` and `toObject`.

Getting this right was surprisingly tricky, as the previous implementation of `newRProxy`,the `RProxy` type, and the `RProxify` mapped type were not set up for converting nested instances of `RObjImpl` into `RObject` during transfer from the worker thread to the main thread. With this PR the returned objects are recursively searched for pointers to R objects (using the new `isRTargetPtr`), with each found object wrapped in a `RProxy` rather than just checking the outermost object.

Searching through objects and replacing things that match a pattern now occurs in a few different places, so I have abstracted it into a `replaceInObject` utility function that tests for objects matching a filter and applies a replacer function if it finds them.

On the worker thread, in addition to updating methods to take a `depth` argument, the `RObjectTree` type is reorganised to take into account that `toTree()` could return items in the `values` property that are any one of:

 * `null`
 * A JS object of some kind, i.e type `RawType`
 * Unconverted R objects, i.e type `RObjImpl`
 * Tree objects one level deeper, i.e. `RObjectTree`

The`RObjectTree<RObjImpl>` type is used for tree objects on the worker thread and can contain instances of `RObjImpl`. `RObjectTree<RObject>` used for tree objects on the main thread and can contain instances of proxied `RObject` instead. The new `RObjectTreeAtomic` type is used for atomic vectors where objects cannot be nested.

`RObjectTree<RObjImpl>` types are automatically converted to `RObjectTree<RObject>` types when they are passed to the main thread by adding a test in the `RProxy` mapped type in `proxy.ts`.

Finally, unit tests are added to check that `{ depth: 1 }` behaves as expected. Older unit tests relying on the old behaviour to check nested values inside returned objects have `{ depth: 0 }` added where required.
