### PR TITLE
WIP: Expand support for creating R objects from the main thread

### DIFF
--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -60,6 +60,13 @@ describe('Working with R lists and vectors', () => {
     expect(await value).toEqual(null);
   });
 
+  test('Set R object names', async () => {
+    const vector = (await webR.evalRCode('c(1, 2, 3)')).result;
+    await vector.names(['d', 'e', 'f']);
+    const value = await vector.names();
+    expect(await value).toEqual(['d', 'e', 'f']);
+  });
+
   test('Get an item with [[ operator', async () => {
     const vector = (await webR.evalRCode('list(a=1, b=2, c=3)')).result;
     let value = (await vector.get('b')) as RDouble;

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -191,7 +191,7 @@ describe('Create R objects from the main thread', () => {
   });
 
   test('Create an environment', async () => {
-    const jsObj = { x: 123, y: 'abc' };
+    const jsObj = { type: 'Environment', names: ['x', 'y'], values: [123, 'abc'] };
     const rObj = (await webR.newRObject(jsObj)) as REnvironment;
     expect(await rObj.type()).toEqual(RType.Environment);
     expect(await rObj.ls()).toEqual(['x', 'y']);
@@ -219,7 +219,11 @@ describe('Create R objects from the main thread', () => {
     ).result as RList;
     const jsObj = await rObj.toTree();
     const newRObj = (await webR.newRObject(jsObj)) as RList;
-    const env = (await webR.newRObject({ newRObj, rObj })) as REnvironment;
+    const env = (await webR.newRObject({
+      type: 'Environment',
+      names: ['newRObj', 'rObj'],
+      values: [newRObj, rObj],
+    })) as REnvironment;
     const identical = (await webR.evalRCode('identical(rObj, newRObj)', env)).result as RLogical;
     expect(await rObj.type()).toEqual(RType.List);
     expect(await identical.toLogical()).toEqual(true);
@@ -233,7 +237,11 @@ describe('Create R objects from the main thread', () => {
     ).result as RList;
     const jsObj = await rObj.toTree({ depth: 1 });
     const newRObj = (await webR.newRObject(jsObj)) as RList;
-    const env = (await webR.newRObject({ newRObj, rObj })) as REnvironment;
+    const env = (await webR.newRObject({
+      type: 'Environment',
+      names: ['newRObj', 'rObj'],
+      values: [newRObj, rObj],
+    })) as REnvironment;
     const identical = (await webR.evalRCode('identical(rObj, newRObj)', env)).result as RLogical;
     expect(await rObj.type()).toEqual(RType.List);
     expect(await identical.toLogical()).toEqual(true);

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -61,7 +61,7 @@ export interface Module extends EmscriptenModule {
   _R_PreserveObject: (ptr: RPtr) => void;
   _R_ReleaseObject: (ptr: RPtr) => void;
   _Rf_ScalarReal: (n: number) => RPtr;
-  _Rf_ScalarLogical: (l: boolean) => RPtr;
+  _Rf_ScalarLogical: (l: number) => RPtr;
   _Rf_ScalarInteger: (n: number) => RPtr;
   _Rf_ScalarString: (s: string) => RPtr;
   _Rf_allocVector: (type: RType, len: number) => RPtr;
@@ -89,6 +89,9 @@ export interface Module extends EmscriptenModule {
   _R_FalseValue: RPtr;
   _R_GlobalEnv: RPtr;
   _R_Interactive: RPtr;
+  _R_NaInt: RPtr;
+  _R_NaReal: RPtr;
+  _R_NaString: RPtr;
   _R_NilValue: RPtr;
   _R_TrueValue: RPtr;
   _R_UnboundValue: RPtr;

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -57,6 +57,7 @@ export interface Module extends EmscriptenModule {
   _VECTOR_ELT: (ptr: RPtr, idx: number) => RPtr;
   _R_lsInternal3: (env: RPtr, all: boolean, sorted: boolean) => RPtr;
   _R_MakeExternalPtr: (p: number, tag: RPtr, prot: RPtr) => RPtr;
+  _R_NewEnv: (enclos: RPtr, hash: number, size: number) => RPtr;
   _R_ParseEvalString: (code: number, env: RPtr) => RPtr;
   _R_PreserveObject: (ptr: RPtr) => void;
   _R_ReleaseObject: (ptr: RPtr) => void;
@@ -66,6 +67,7 @@ export interface Module extends EmscriptenModule {
   _Rf_ScalarString: (s: string) => RPtr;
   _Rf_allocList: (len: number) => RPtr;
   _Rf_allocVector: (type: RType, len: number) => RPtr;
+  _Rf_defineVar: (symbol: RPtr, value: RPtr, env: RPtr) => void;
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
   _Rf_listAppend: (source: RPtr, target: RPtr) => RPtr;

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -69,6 +69,7 @@ export interface Module extends EmscriptenModule {
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
   _Rf_listAppend: (source: RPtr, target: RPtr) => RPtr;
+  _Rf_getAttrib: (ptr1: RPtr, ptr2: RPtr) => RPtr;
   _Rf_install: (ptr: number) => RPtr;
   _Rf_installTrChar: (name: RPtr) => RPtr;
   _Rf_lang1: (ptr1: RPtr) => RPtr;
@@ -81,6 +82,7 @@ export interface Module extends EmscriptenModule {
   _Rf_mkString: (ptr: number) => RPtr;
   _Rf_onintr: () => void;
   _Rf_protect: (ptr: RPtr) => RPtr;
+  _Rf_setAttrib: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr) => RPtr;
   _Rf_unprotect: (n: number) => void;
   _Rf_unprotect_ptr: (ptr: RPtr) => void;
   _R_BaseEnv: RPtr;
@@ -96,6 +98,7 @@ export interface Module extends EmscriptenModule {
   _R_NaString: RPtr;
   _R_NilValue: RPtr;
   _R_TrueValue: RPtr;
+  _R_NamesSymbol: RPtr;
   _R_UnboundValue: RPtr;
   _SET_STRING_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;
   _SET_VECTOR_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -64,9 +64,11 @@ export interface Module extends EmscriptenModule {
   _Rf_ScalarLogical: (l: number) => RPtr;
   _Rf_ScalarInteger: (n: number) => RPtr;
   _Rf_ScalarString: (s: string) => RPtr;
+  _Rf_allocList: (len: number) => RPtr;
   _Rf_allocVector: (type: RType, len: number) => RPtr;
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
+  _Rf_listAppend: (source: RPtr, target: RPtr) => RPtr;
   _Rf_install: (ptr: number) => RPtr;
   _Rf_installTrChar: (name: RPtr) => RPtr;
   _Rf_lang1: (ptr1: RPtr) => RPtr;

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -158,6 +158,15 @@ function newRObjFromTarget(target: RTargetObj): RObjImpl {
     return new RObjList(tree);
   }
 
+  if (typeof obj === 'object') {
+    const tree = {
+      type: 'List',
+      names: Object.keys(obj),
+      values: Object.values(obj),
+    };
+    return new RObjList(tree as NamedObject<RawType>);
+  }
+
   throw new Error('Robj construction for this JS object is not yet supported');
 }
 

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -195,10 +195,10 @@ export class RObjImpl {
   }
 
   get [Symbol.toStringTag](): string {
-    return `RObj:${RType[this.type]}`;
+    return `RObj:${RType[this.type()]}`;
   }
 
-  get type(): RType {
+  type(): RType {
     return Module._TYPEOF(this.ptr);
   }
 
@@ -497,7 +497,7 @@ export class RObjPairlist extends RObjImpl {
       }
     }
     const names = hasNames ? namesArray : null;
-    return { type: RType[this.type], names, values };
+    return { type: RType[this.type()], names, values };
   }
 
   includes(name: string): boolean {
@@ -557,7 +557,7 @@ export class RObjList extends RObjImpl {
 
   toTree(options: { depth: number } = { depth: 0 }, depth = 1): RObjectTree<RObjImpl> {
     return {
-      type: RType[this.type],
+      type: RType[this.type()],
       names: this.names(),
       values: [...Array(this.length).keys()].map((i) => {
         if (options.depth && depth >= options.depth) {
@@ -648,7 +648,7 @@ export class RObjEnvironment extends RObjImpl {
     });
 
     return {
-      type: RType[this.type],
+      type: RType[this.type()],
       names,
       values,
     };
@@ -729,7 +729,7 @@ abstract class RObjAtomicVector<T extends atomicType> extends RObjImpl {
 
   toTree(): RObjectTreeAtomic<T> {
     return {
-      type: RType[this.type],
+      type: RType[this.type()],
       names: this.names(),
       values: this.toArray(),
       missing: this.detectMissing(),

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -162,9 +162,7 @@ export class WebR {
     const targetObj = replaceInObject(jsObj, isRObject, (obj: RObject) => obj._target);
     const target = (await this.#chan.request({
       type: 'newRObject',
-      data: {
-        obj: { type: RTargetType.RAW, obj: targetObj },
-      },
+      data: { type: RTargetType.RAW, obj: targetObj },
     })) as RTargetObj;
     switch (target.type) {
       case RTargetType.RAW:

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -300,7 +300,7 @@ function evalRCode(code: string, env?: RPtr, options: EvalRCodeOptions = {}): RT
   let envObj = RObjImpl.globalEnv;
   if (env) {
     envObj = RObjImpl.wrap(env);
-    if (envObj.type !== RType.Environment) {
+    if (envObj.type() !== RType.Environment) {
       throw new Error('Attempted to eval R code with an env argument with invalid SEXP type');
     }
   }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -90,11 +90,9 @@ function dispatch(msg: Message): void {
           break;
         }
         case 'newRObject': {
-          const data = reqMsg.data as {
-            obj: RTargetRaw;
-          };
+          const data = reqMsg.data as RTargetRaw;
           try {
-            const res = new RObjImpl(data.obj);
+            const res = new RObjImpl(data);
             write({ obj: res.ptr, methods: RObjImpl.getMethods(res), type: RTargetType.PTR });
           } catch (_e) {
             const e = _e as Error;


### PR DESCRIPTION
Includes #79.

This PR expands support for creating R objects from the main thread using `webR.newRObject()`. Creating lists, pairlists, atomic vectors, and environments is supported.

Atomic vectors can be created from JS scalars or arrays containing identical types. Lists and pairlists can be created from JS arrays with mixed types. Environments can be created from JS objects using the key/value pairs.

Creating new R objects from JS objects passed to `webR.newRObject()` in the form of an `RObjectTree<T>` (i.e. the type of the result obtained by running `RObjImpl.toTree()`) is also supported, and so round trip conversions are possible.

`RProxy` objects can also be passed to `webR.newRObject()` to be included in lists or environments.

The `RObjImpl` subclass constructors each create an R object of that type from a compatible JS object or `RTargetObj ` (derived from an `RProxy` passed from the main thread). Creating an object using the general `RObjImpl` constructor instead invokes `newRObjFromTarget` to try and choose the best type of object to create, and then invokes that type's subclass constructor.

A few other utility changes:
 * `RObjImpl.type()` is now a method so that it can be accessed from the main thread.
 * `names()` now takes an optional argument to set the names attribute.
 * `REnvironment` now has a `define(name, value)` method to add an object to an environment. *(Note: this was originally used in `newRObjFromTarget`, but no longer used there. However, it seems a shame to remove the method again now.)*
 * `RObjImpl.naInt`/`naReal`/`naString` returns the `NA` sentinels.

TODO:
 * Passing in a list of lists should be supported for creating objects using key/value pairs.