### PR TITLE
Install parallel package

### DIFF
--- a/patches/R-4.1.3/emscripten-makefiles.diff
+++ b/patches/R-4.1.3/emscripten-makefiles.diff
@@ -19,7 +19,7 @@ Index: R-4.1.3/src/main/Makefile.in
 ===================================================================
 --- R-4.1.3.orig/src/main/Makefile.in
 +++ R-4.1.3/src/main/Makefile.in
-@@ -147,6 +147,35 @@ R: Makedeps
+@@ -147,6 +147,34 @@ R: Makedeps
  $(R_binary): $(R_bin_OBJECTS) $(R_bin_DEPENDENCIES)
  	$(MAIN_LINK) -o $@ $(R_bin_OBJECTS) $(R_bin_LDADD)
  
@@ -39,7 +39,6 @@ Index: R-4.1.3/src/main/Makefile.in
 +	@cp -a "$(prefix)/lib" "$(prefix)/tmp/"
 +	@rm -r "$(prefix)/tmp/lib/R/library/translations"
 +	@rm -r "$(prefix)/tmp/lib/R/library/tcltk"
-+	@rm -r "$(prefix)/tmp/lib/R/library/parallel"
 +	@rm -r "$(prefix)/tmp/lib/R/bin"
 +	@rm -r "$(prefix)/tmp/lib/R/include"
 +	$(MAIN_LINK) $(MAIN_WEBR_LDADD) \


### PR DESCRIPTION
Needed for tinytest, and in turn to test packages like digest.

Hopefully this doesn't break anything? I couldn't see any negative effect after applying this patch.