### PR TITLE
Rework `enum`s into objects, suggested as a TypeScript best practice

### DIFF
--- a/src/tests/webR/proxy.test.ts
+++ b/src/tests/webR/proxy.test.ts
@@ -1,5 +1,5 @@
 import { WebR } from '../../webR/webr-main';
-import { RDouble, RFunction, RList } from '../../webR/robj';
+import { RDouble, RFunction, RList, RTargetType } from '../../webR/robj';
 import util from 'util';
 
 const webR = new WebR({
@@ -18,10 +18,12 @@ test('Evaluate code and return a proxy', async () => {
 
 test('RProxy _target property', async () => {
   const result = (await webR.evalRCode('42')).result;
-  expect(result._target).toHaveProperty('type', 'PTR');
-  expect(result._target).toHaveProperty('methods');
+  expect(result._target).toHaveProperty('targetType', RTargetType.ptr);
   expect(result._target).toHaveProperty('obj');
-  expect(result._target.obj).toEqual(expect.any(Number));
+  const obj = result._target.obj as { type: string; methods: string[]; ptr: number };
+  expect(obj.type).toEqual('double');
+  expect(obj.methods[0]).toEqual(expect.any(String));
+  expect(obj.ptr).toEqual(expect.any(Number));
 });
 
 test('RFunctions can be invoked via the proxy apply hook', async () => {

--- a/src/tests/webR/proxy.test.ts
+++ b/src/tests/webR/proxy.test.ts
@@ -1,5 +1,5 @@
 import { WebR } from '../../webR/webr-main';
-import { RDouble, RFunction, RList, RTargetType } from '../../webR/robj';
+import { RDouble, RFunction, RList } from '../../webR/robj';
 import util from 'util';
 
 const webR = new WebR({
@@ -18,7 +18,7 @@ test('Evaluate code and return a proxy', async () => {
 
 test('RProxy _target property', async () => {
   const result = (await webR.evalRCode('42')).result;
-  expect(result._target).toHaveProperty('targetType', RTargetType.ptr);
+  expect(result._target).toHaveProperty('targetType', 'ptr');
   expect(result._target).toHaveProperty('obj');
   const obj = result._target.obj as { type: string; methods: string[]; ptr: number };
   expect(obj.type).toEqual('double');

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -39,7 +39,7 @@ test('Convert an R symbol to JS', async () => {
 
 test('Get RObject type as a string', async () => {
   const result = (await webR.evalRCode('NULL')).result as RNull;
-  expect(await result.toString()).toEqual('[object RObj:Null]');
+  expect(await result.toString()).toEqual('[object RObj:null]');
 });
 
 describe('Working with R lists and vectors', () => {
@@ -187,13 +187,13 @@ describe('Working with R lists and vectors', () => {
   test('Converted object has type property', async () => {
     const list = (await webR.evalRCode('list(1,2,3)')).result as RList;
     const listJs = await list.toJs();
-    expect(listJs.type).toEqual('List');
+    expect(listJs.type).toEqual('list');
     const logical = (await webR.evalRCode('TRUE')).result as RLogical;
     const logicalJs = await logical.toJs();
-    expect(logicalJs.type).toEqual('Logical');
+    expect(logicalJs.type).toEqual('logical');
     const double = (await webR.evalRCode('c(1,2,3)')).result as RDouble;
     const doubleJs = await double.toJs();
-    expect(doubleJs.type).toEqual('Double');
+    expect(doubleJs.type).toEqual('double');
   });
 
   test('First key wins when converting R objects to JS objects', async () => {
@@ -335,7 +335,7 @@ describe('Working with R lists and vectors', () => {
 describe('Working with R environments', () => {
   test('Create an R environment', async () => {
     const env = (await webR.evalRCode('new.env()')).result as REnvironment;
-    expect(await env.toString()).toEqual('[object RObj:Environment]');
+    expect(await env.toString()).toEqual('[object RObj:environment]');
   });
 
   test('List items in an R environment', async () => {

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -51,6 +51,7 @@ describe('Evaluate R code', () => {
 
   test('Throw an error if passed an invalid environment object type', async () => {
     const euler = (await webR.evalRCode('0.57722')).result;
+    // @ts-expect-error Deliberate type error to test Error thrown
     await expect(webR.evalRCode('x', euler)).rejects.toThrow('env argument with invalid SEXP type');
   });
 

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -46,18 +46,20 @@ export interface ChannelWorker {
   setDispatchHandler: (dispatch: (msg: Message) => void) => void;
 }
 
-export enum ChannelType {
-  Automatic,
-  SharedArrayBuffer,
-  ServiceWorker,
-  PostMessage,
-}
+export const ChannelType = {
+  Automatic: 0,
+  SharedArrayBuffer: 1,
+  ServiceWorker: 2,
+} as const;
 
 export type ChannelInitMessage = {
   type: string;
   data: {
     config: Required<WebROptions>;
-    channelType: Exclude<ChannelType, ChannelType.Automatic>;
+    channelType: Exclude<
+      typeof ChannelType[keyof typeof ChannelType],
+      typeof ChannelType.Automatic
+    >;
     clientId?: string;
     location?: string;
   };

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -64,7 +64,7 @@ export interface Module extends EmscriptenModule {
   _Rf_ScalarLogical: (l: boolean) => RPtr;
   _Rf_ScalarInteger: (n: number) => RPtr;
   _Rf_ScalarString: (s: string) => RPtr;
-  _Rf_allocVector: (type: RType, len: number) => RPtr;
+  _Rf_allocVector: (type: typeof RType[keyof typeof RType], len: number) => RPtr;
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
   _Rf_install: (ptr: number) => RPtr;

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -1,4 +1,4 @@
-import type { RPtr, RType } from './robj';
+import type { RPtr, RTypeNumber } from './robj';
 
 export interface Module extends EmscriptenModule {
   /* Add mkdirTree to FS namespace, missing from @types/emscripten at the
@@ -64,7 +64,7 @@ export interface Module extends EmscriptenModule {
   _Rf_ScalarLogical: (l: boolean) => RPtr;
   _Rf_ScalarInteger: (n: number) => RPtr;
   _Rf_ScalarString: (s: string) => RPtr;
-  _Rf_allocVector: (type: typeof RType[keyof typeof RType], len: number) => RPtr;
+  _Rf_allocVector: (type: RTypeNumber, len: number) => RPtr;
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
   _Rf_install: (ptr: number) => RPtr;

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -1,4 +1,4 @@
-import { RTargetType, RTargetPtr, isRObject, RTargetObj, RObjectTree, RObject } from './robj';
+import { RTargetPtr, isRObject, RTargetObj, RObjectTree, RObject } from './robj';
 import { RObjImpl, RObjFunction, RawType, isRFunction, isRTargetPtr } from './robj';
 import { ChannelMain } from './chan/channel';
 import { replaceInObject } from './utils';
@@ -77,7 +77,7 @@ function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RObjImpl>) {
     })) as RTargetObj;
 
     // Throw an error if there was some problem accessing the object length
-    if (reply.targetType === RTargetType.err) {
+    if (reply.targetType === 'err') {
       const e = new Error(`Cannot iterate over object, ${reply.obj.message}`);
       e.name = reply.obj.name;
       e.stack = reply.obj.stack;
@@ -100,7 +100,7 @@ function targetMethod(chan: ChannelMain, target: RTargetPtr, prop: string) {
   return async (..._args: unknown[]) => {
     const args = Array.from({ length: _args.length }, (_, idx) => {
       const arg = _args[idx];
-      return isRObject(arg) ? arg._target : { obj: arg, targetType: RTargetType.raw };
+      return isRObject(arg) ? arg._target : { obj: arg, targetType: 'raw' };
     });
 
     const reply = (await chan.request({
@@ -109,9 +109,9 @@ function targetMethod(chan: ChannelMain, target: RTargetPtr, prop: string) {
     })) as RTargetObj;
 
     switch (reply.targetType) {
-      case RTargetType.ptr:
+      case 'ptr':
         return newRProxy(chan, reply);
-      case RTargetType.err: {
+      case 'err': {
         const e = new Error(reply.obj.message);
         e.name = reply.obj.name;
         e.stack = reply.obj.stack;

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -5,7 +5,6 @@ import { newRProxy } from './proxy';
 import { unpackScalarVectors, replaceInObject } from './utils';
 import {
   RTargetObj,
-  RTargetType,
   RObject,
   isRObject,
   RawType,
@@ -133,9 +132,9 @@ export class WebR {
     })) as RTargetObj;
 
     switch (target.targetType) {
-      case RTargetType.raw:
+      case 'raw':
         throw new Error('Unexpected raw target type returned from evalRCode');
-      case RTargetType.err: {
+      case 'err': {
         const e = new Error(target.obj.message);
         e.name = target.obj.name;
         e.stack = target.obj.stack;
@@ -163,12 +162,12 @@ export class WebR {
     const targetObj = replaceInObject(jsObj, isRObject, (obj: RObject) => obj._target);
     const target = (await this.#chan.request({
       type: 'newRObject',
-      data: { targetType: RTargetType.raw, obj: targetObj },
+      data: { targetType: 'raw', obj: targetObj },
     })) as RTargetObj;
     switch (target.targetType) {
-      case RTargetType.raw:
+      case 'raw':
         throw new Error('Unexpected raw target type returned from newRObject');
-      case RTargetType.err: {
+      case 'err': {
         const e = new Error(target.obj.message);
         e.name = target.obj.name;
         e.stack = target.obj.stack;

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -40,7 +40,7 @@ export interface WebROptions {
   SW_URL?: string;
   homedir?: string;
   interactive?: boolean;
-  channelType?: ChannelType;
+  channelType?: typeof ChannelType[keyof typeof ChannelType];
 }
 
 const defaultEnv = {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -5,15 +5,7 @@ import { FSNode, WebROptions, EvalRCodeOptions } from './webr-main';
 import { Module } from './module';
 import { IN_NODE } from './compat';
 import { replaceInObject } from './utils';
-import {
-  isRObjImpl,
-  RObjImpl,
-  RTargetObj,
-  RTargetPtr,
-  RTargetType,
-  RawType,
-  RTargetRaw,
-} from './robj';
+import { isRObjImpl, RObjImpl, RTargetObj, RTargetPtr, RawType, RTargetRaw } from './robj';
 
 let initialised = false;
 let chan: ChannelWorker | undefined;
@@ -81,7 +73,7 @@ function dispatch(msg: Message): void {
           } catch (_e) {
             const e = _e as Error;
             write({
-              targetType: RTargetType.err,
+              targetType: 'err',
               obj: { name: e.name, message: e.message, stack: e.stack },
             });
           }
@@ -97,12 +89,12 @@ function dispatch(msg: Message): void {
                 ptr: res.ptr,
                 methods: RObjImpl.getMethods(res),
               },
-              targetType: RTargetType.ptr,
+              targetType: 'ptr',
             });
           } catch (_e) {
             const e = _e as Error;
             write({
-              targetType: RTargetType.err,
+              targetType: 'err',
               obj: { name: e.name, message: e.message, stack: e.stack },
             });
           }
@@ -119,7 +111,7 @@ function dispatch(msg: Message): void {
           } catch (_e) {
             const e = _e as Error;
             write({
-              targetType: RTargetType.err,
+              targetType: 'err',
               obj: { name: e.name, message: e.message, stack: e.stack },
             });
           }
@@ -135,7 +127,7 @@ function dispatch(msg: Message): void {
           } catch (_e) {
             const e = _e as Error;
             write({
-              targetType: RTargetType.err,
+              targetType: 'err',
               obj: { name: e.name, message: e.message, stack: e.stack },
             });
           }
@@ -235,18 +227,18 @@ function callRObjMethod(obj: RObjImpl, prop: string, args: RTargetObj[]): RTarge
     obj,
     Array.from({ length: args.length }, (_, idx) => {
       const arg = args[idx];
-      return arg.targetType === RTargetType.ptr ? RObjImpl.wrap(arg.obj.ptr) : arg.obj;
+      return arg.targetType === 'ptr' ? RObjImpl.wrap(arg.obj.ptr) : arg.obj;
     })
   ) as RawType | RObjImpl;
 
   const ret = replaceInObject(res, isRObjImpl, (obj: RObjImpl) => {
     return {
       obj: { type: obj.type(), ptr: obj.ptr, methods: RObjImpl.getMethods(obj) },
-      targetType: RTargetType.ptr,
+      targetType: 'ptr',
     };
   }) as RawType;
 
-  return { obj: ret, targetType: RTargetType.raw };
+  return { obj: ret, targetType: 'raw' };
 }
 
 /**
@@ -268,10 +260,10 @@ function getRObjProperty(obj: RObjImpl, prop: string): RTargetObj {
   if (isRObjImpl(res)) {
     return {
       obj: { type: res.type(), ptr: res.ptr, methods: RObjImpl.getMethods(res) },
-      targetType: RTargetType.ptr,
+      targetType: 'ptr',
     };
   } else {
-    return { obj: res, targetType: RTargetType.raw };
+    return { obj: res, targetType: 'raw' };
   }
 }
 
@@ -318,7 +310,7 @@ function evalRCode(code: string, env?: RTargetPtr, options: EvalRCodeOptions = {
   const fPtr = Module.getValue(Module._R_FalseValue, '*');
   const codeStr = Module.allocateUTF8(code);
   const evalStr = Module.allocateUTF8('webr:::evalRCode');
-  const codeObj = new RObjImpl({ targetType: RTargetType.raw, obj: code });
+  const codeObj = new RObjImpl({ targetType: 'raw', obj: code });
   codeObj.preserve();
   const expr = Module._Rf_lang6(
     Module._R_ParseEvalString(evalStr, RObjImpl.baseEnv.ptr),
@@ -334,7 +326,7 @@ function evalRCode(code: string, env?: RTargetPtr, options: EvalRCodeOptions = {
   Module._free(evalStr);
   return {
     obj: { type: evalResult.type(), ptr: evalResult.ptr, methods: RObjImpl.getMethods(evalResult) },
-    targetType: RTargetType.ptr,
+    targetType: 'ptr',
   };
 }
 


### PR DESCRIPTION
 * Switch from using `enum` for `RType` and others in favour of JS objects.
 * Switch to using lowercase property names.
 * Tweak the `RObjectPtr` structure to better match structure of `RObjectRaw` and `RObjectErr`.
* Change the `type` property name on `RTargetObj` to be named `targetType`, to avoid confusion with `RType`.
 * Make `RObjImpl.type()` a standard method rather than a computed property.
 * Tweak and simplify the R object duck typing tests to take into account the changes.

Many changes are just renaming such as `type` -> `targetType` and uppercase to lowercase. Apologies for not separating those out further into their own commit - it only just occurred to me.