### PR TITLE
Add `setNames()` method for setting the names attribute on an R Object

### DIFF
--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -60,6 +60,17 @@ describe('Working with R lists and vectors', () => {
     expect(await value).toEqual(null);
   });
 
+  test('Set R object names', async () => {
+    const vector = (await webR.evalRCode('c(1, 2, 3)')).result;
+    await vector.setNames(['d', 'e', 'f']);
+    const value = await vector.names();
+    expect(await value).toEqual(['d', 'e', 'f']);
+
+    // @ts-expect-error Deliberate type error to test Error thrown
+    const err = vector.setNames(123);
+    await expect(err).rejects.toThrow('setNames must be null or an Array of strings or null');
+  });
+
   test('Get an item with [[ operator', async () => {
     const vector = (await webR.evalRCode('list(a=1, b=2, c=3)')).result;
     let value = (await vector.get('b')) as RDouble;

--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -67,6 +67,7 @@ export interface Module extends EmscriptenModule {
   _Rf_allocVector: (type: RTypeNumber, len: number) => RPtr;
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
+  _Rf_getAttrib: (ptr1: RPtr, ptr2: RPtr) => RPtr;
   _Rf_install: (ptr: number) => RPtr;
   _Rf_installTrChar: (name: RPtr) => RPtr;
   _Rf_lang1: (ptr1: RPtr) => RPtr;
@@ -79,6 +80,7 @@ export interface Module extends EmscriptenModule {
   _Rf_mkString: (ptr: number) => RPtr;
   _Rf_onintr: () => void;
   _Rf_protect: (ptr: RPtr) => RPtr;
+  _Rf_setAttrib: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr) => RPtr;
   _Rf_unprotect: (n: number) => void;
   _Rf_unprotect_ptr: (ptr: RPtr) => void;
   _R_BaseEnv: RPtr;
@@ -89,8 +91,10 @@ export interface Module extends EmscriptenModule {
   _R_FalseValue: RPtr;
   _R_GlobalEnv: RPtr;
   _R_Interactive: RPtr;
+  _R_NaString: RPtr;
   _R_NilValue: RPtr;
   _R_TrueValue: RPtr;
+  _R_NamesSymbol: RPtr;
   _R_UnboundValue: RPtr;
   _SET_STRING_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;
   _SET_VECTOR_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;


### PR DESCRIPTION
Includes #86.

Note: Individually setting names elements with `Module._SET_STRING_ELT` is replaced in favour of using a `RObjCharacter` constructor in the next linked PR.