### PR TITLE
Fix missing FCLEN in dtptrs F77_NAME call

### DIFF
--- a/patches/R-4.1.3/fix-dtptrs.diff
+++ b/patches/R-4.1.3/fix-dtptrs.diff
@@ -1,0 +1,13 @@
+Index: R-4.1.3/src/include/R_ext/Lapack.h
+===================================================================
+--- R-4.1.3.orig/src/include/R_ext/Lapack.h
++++ R-4.1.3/src/include/R_ext/Lapack.h
+@@ -1484,7 +1484,7 @@ F77_NAME(dtptrs)(const char* uplo, const char* trans,
+ 		 const char* diag, const int* n,
+ 		 const int* nrhs, const double* ap,
+ 		 double* b, const int* ldb, int* info
+-		 FCLEN FCLEN);
++		 FCLEN FCLEN FCLEN);
+ 
+ 
+ //* Double precision TRiangular matrices -> DTR

--- a/patches/R-4.1.3/series
+++ b/patches/R-4.1.3/series
@@ -16,3 +16,4 @@ emscripten-disable-bcEval.diff
 emscripten-xhr-download.diff
 fix-signrank-wilcox.diff
 emscripten-avoid-testing-issues.diff
+fix-dtptrs.diff


### PR DESCRIPTION
If I am understanding how all this works correctly, the Lapack function `dtptrs` takes three `char*` arguments in its arguments list. As such, it should have three invocations of the `FCLEN` macro after the usual argument list for portability reasons. Possibly this only really matters in WASM, where it is vital that argument signatures are consistent. Even so, if I am correct this might be considered an R bug.

Without this change, Matrix fails to load under WASM with the error,
```
Could not load dynamic lib: /usr/lib/R/library/Matrix/libs/Matrix.so
LinkError: WebAssembly.Instance(): Import #148 module="env" function="dtptrs_" error:
imported function does not match the expected type.
```
This is an improvement to a previous "fix" for that error, which was to just comment out the `F77_CALL` entirely.

See also the required corresponding commit to: [georgestagg/Matrix@webr](https://github.com/cran/Matrix/commit/8770e5f61a7bea278ae788d8f865e91e09bd4f6e) to fix the error.