### PR TITLE
Negate the text rotation value `rot` before formatting the double for the HTML canvas API

### DIFF
--- a/patches/R-4.1.3/emscripten-canvas-device.diff
+++ b/patches/R-4.1.3/emscripten-canvas-device.diff
@@ -367,7 +367,7 @@ Index: R-4.1.3/src/library/grDevices/src/devCanvas.c
 +			canvasContextExec(cGD, ("save()"));
 +			canvasColor(fillStyle,gc->col);
 +			canvasContextExec(cGD, ("translate(%f,%f)"), 2*x, 2*y);
-+			canvasContextExec(cGD, ("rotate(-%f / 180 * Math.PI)"), rot);
++			canvasContextExec(cGD, ("rotate(%f / 180 * Math.PI)"), -rot);
 +			canvasContextExec(cGD, ("fillText(decodeURIComponent(\\`%s\\`),-%f*%f,0)"), enc, 2*wi, hadj);
 +			canvasContextExec(cGD, ("restore()"));
 +		} else {


### PR DESCRIPTION
Avoids an issue where double negation is formatted as a repeated `-` symbol, rather than cancelling, when rotating text clockwise using the HTML canvas graphics device patched into R for webR.

Fixes #93.