### PR TITLE
Turn off wasm decoding

### DIFF
--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -11,6 +11,7 @@ export interface Module extends EmscriptenModule {
   monitorRunDependencies: (n: number) => void;
   noImageDecoding: boolean;
   noAudioDecoding: boolean;
+  noWasmDecoding: boolean;
   setPrompt: (prompt: string) => void;
   canvasExec: (op: string) => void;
   downloadFileContent: (

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -353,6 +353,12 @@ function init(config: Required<WebROptions>) {
   Module.noAudioDecoding = true;
   Module.noInitialRun = true;
 
+  // Don't instantiate .so libraries packaged through `WEBR_REPO` too
+  // early. Otherwise C++ libraries with dynamic initialisation of
+  // global variables might call into the R API too early, beforeR has
+  // started.
+  Module.noWasmDecoding = true;
+
   Module.preRun.push(() => {
     if (IN_NODE) {
       globalThis.FS = Module.FS;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -355,7 +355,7 @@ function init(config: Required<WebROptions>) {
 
   // Don't instantiate .so libraries packaged through `WEBR_REPO` too
   // early. Otherwise C++ libraries with dynamic initialisation of
-  // global variables might call into the R API too early, beforeR has
+  // global variables might call into the R API too early, before R has
   // started.
   Module.noWasmDecoding = true;
 


### PR DESCRIPTION
The webR build supports setting `WEBR_REPO` to a local repo. When set, the repo is preloaded with `--preload-file` so that webR starts with packages already installed.

This works fine except for packages with C++ libraries that dynamically initialise global variables using the R API, e.g. a top-level:

```cpp
SEXP sym = Rf_install("foo")
```

dplyr does this for instance. When this happens and `noWasmDecoding` isn't set, Emscripten instantiates these variables before R has started, causing a crash.