### PR TITLE
Fix timezone support

### DIFF
--- a/R/Makefile
+++ b/R/Makefile
@@ -146,7 +146,8 @@ $(BUILD)/state/r-stage2-configured: $(BUILD)/state/r-patched $(FORTRAN_WASM_LIB)
 	    --disable-nls \
 	    --enable-byte-compiled-packages=no \
 	    --enable-static=yes \
-	    --host=wasm32-unknown-emscripten
+	    --host=wasm32-unknown-emscripten \
+	    --with-internal-tzcode
 # Disable umask which doesn't work well within Emscripten. Fixes
 # permission issues when extracting tarballs.
 	sed -i.bak '/D\["HAVE_UMASK"\]/d' $(R_SOURCE)/build/config.status

--- a/packages/webr/inst/tests-webr/test-webr.R
+++ b/packages/webr/inst/tests-webr/test-webr.R
@@ -13,3 +13,25 @@ webr:::sandbox({
     identical(system2("cmd"), "foo")
   )
 })
+
+"timezone is set"
+webr:::sandbox({
+  tz <- Sys.timezone()
+
+  # Used to be NA
+  stopifnot(
+    is.character(tz) && length(tz) == 1 && !is.na(tz)
+  )
+})
+
+"POSIXlt supports time zones"
+webr:::sandbox({
+  out <- as.POSIXlt("2013-06-17 22:33:44", tz = "Australia/Darwin")
+
+  stopifnot(
+    identical(
+      unclass(out)$zone,
+      "ACST"
+    )
+  )
+})

--- a/patches/R-4.1.3/emscripten-makefiles.diff
+++ b/patches/R-4.1.3/emscripten-makefiles.diff
@@ -2,7 +2,7 @@ Index: R-4.1.3/Makefile.in
 ===================================================================
 --- R-4.1.3.orig/Makefile.in
 +++ R-4.1.3/Makefile.in
-@@ -90,6 +90,12 @@ stamp-java : etc/Makeconf etc/javaconf $
+@@ -90,6 +90,13 @@ stamp-java : etc/Makeconf etc/javaconf $
  javaconf: R
  	@$(MAKE) stamp-java
  
@@ -11,6 +11,7 @@ Index: R-4.1.3/Makefile.in
 +	@for d in $(SUBDIRS); do \
 +	  (cd $${d} && $(MAKE) install) \
 +	done
++	-@(cd share && $(MAKE) install-zoneinfo)
 +	-@(cd src/main && $(MAKE) $@)
  
  install install-strip: installdirs svnonly

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -570,6 +570,12 @@ function evalR(code: string, env?: WebRPayloadPtr): RObject {
 function init(config: Required<WebROptions>) {
   _config = config;
 
+  const env = { ...config.REnv };
+  if (!env.TZ) {
+    const fmt = new Intl.DateTimeFormat();
+    env.TZ = fmt.resolvedOptions().timeZone;
+  }
+
   Module.preRun = [];
   Module.arguments = _config.RArgs;
   Module.noExitRuntime = true;
@@ -590,7 +596,8 @@ function init(config: Required<WebROptions>) {
     Module.FS.mkdirTree(_config.homedir);
     Module.ENV.HOME = _config.homedir;
     Module.FS.chdir(_config.homedir);
-    Module.ENV = Object.assign(Module.ENV, _config.REnv);
+
+    Module.ENV = Object.assign(Module.ENV, env);
   });
 
   chan?.setDispatchHandler(dispatch);


### PR DESCRIPTION
Without these changes:

```r
# `$zone` component is not set to "ACST"
as.POSIXlt("2013-06-17 22:33:44", tz="Australia/Darwin")

# Returns `NA`
Sys.timezone()
```

WIP: I'd like to add unit tests, but I haven't been able to run them locally yet.