### PR TITLE
Add `libpng` to `wasm/lib`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /dist
 /host
+/libs/build
+/libs/download
 /wasm
 /tools/fortran.mk
 /tools/dragonegg/build

--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,17 @@ EMFC_FILES = $(EMFC) $(FORTRAN_WASM_LIB)
 
 # Build webR and install the web app in `./dist`
 .PHONY: webr
-webr: $(EMFC_FILES)
+webr: $(EMFC_FILES) libs
 	cd R && $(MAKE) && $(MAKE) install
 	cd src && $(MAKE)
 
 $(EMFC_FILES):
 	cd $(EMFC_DIR) && $(MAKE) && $(MAKE) install
 
-
-# Supporting libs for packages of webr-repo
+# Supporting libs for webr
 .PHONY: libs
 libs:
 	cd libs && $(MAKE)
-
 
 # Build webR in a temporary docker container
 .PHONY: docker-webr

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,18 @@ check-pr:
 	cd src && $(MAKE) lint && $(MAKE) check && $(MAKE) check-packages
 
 .PHONY: clean
-clean: clean-webr
+clean: clean-wasm
 	cd tools/dragonegg && $(MAKE) clean
 	cd tools/flang && $(MAKE) clean
 
+.PHONY: clean-wasm
+clean-wasm: clean-webr
+	rm -rf wasm
+	cd libs && $(MAKE) clean
+
 .PHONY: clean-webr
 clean-webr:
-	rm -rf host wasm
+	rm -rf host
 	cd R && $(MAKE) clean
 
 .PHONY: distclean

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ webr: $(EMFC_FILES)
 $(EMFC_FILES):
 	cd $(EMFC_DIR) && $(MAKE) && $(MAKE) install
 
+
+# Supporting libs for packages of webr-repo
+.PHONY: libs
+libs:
+	cd libs && $(MAKE)
+
+
 # Build webR in a temporary docker container
 .PHONY: docker-webr
 docker-webr:

--- a/R/Makefile
+++ b/R/Makefile
@@ -21,18 +21,6 @@ R_URL = https://cran.r-project.org/src/base/R-4/R-$(R_VERSION).tar.gz
 R_HOST = $(HOST)/R-$(R_VERSION)
 R_WASM = $(WASM)/R-$(R_VERSION)
 
-PCRE_VERSION = 10.39
-PCRE_TARBALL = $(DOWNLOAD)/pcre2-$(PCRE_VERSION).tar.gz
-PCRE_URL = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${PCRE_VERSION}/pcre2-$(PCRE_VERSION).tar.gz
-PCRE_WASM_LIB = $(WASM)/lib/libpcre2-8.a
-
-XZ_VERSION = 5.2.5
-XZ_TARBALL = $(DOWNLOAD)/xz-$(XZ_VERSION).tar.gz
-XZ_URL = https://tukaani.org/xz/xz-$(XZ_VERSION).tar.gz/download
-XZ_WASM_LIB = $(WASM)/lib/liblzma.a
-
-WASM_LIBS = $(PCRE_WASM_LIB) $(XZ_WASM_LIB) $(FORTRAN_WASM_LIB)
-
 # Configure your local environment in this file
 -include ~/.webr-config.mk
 export WEBR_REPO
@@ -76,26 +64,26 @@ $(BUILD)/state/r-stage1-configured: $(BUILD)/state/r-patched
 	  touch NEWS NEWS.pdf NEWS.rds NEWS.2.rds NEWS.3.rds
 	cd $(R_SOURCE)/build-stage1 && \
 	  FC="$(STAGE1_FC)" \
-	    CXX="$(STAGE1_CXX)" \
-	    CC="$(STAGE1_CC)" \
-	    FC="$(STAGE1_FC)" \
-	    CPPFLAGS="$(STAGE1_CPPFLAGS)" \
-	    CFLAGS="$(STAGE1_CFLAGS)" \
-	    LDFLAGS="$(STAGE1_LDFLAGS)" \
-	    ../configure \
-	      --prefix="$(R_HOST)" \
-	      --with-x=no \
-	      --with-aqua=no \
-	      --with-readline=no \
-	      --with-jpeglib=no \
-	      --with-cairo=no \
-	      --disable-openmp \
-	      --with-recommended-packages=no \
-	      --enable-R-profiling=no \
-	      --with-pcre2 \
-	      --disable-nls \
-	      --enable-byte-compiled-packages=no \
-	      --enable-long-double=no
+	  CXX="$(STAGE1_CXX)" \
+	  CC="$(STAGE1_CC)" \
+	  FC="$(STAGE1_FC)" \
+	  CPPFLAGS="$(STAGE1_CPPFLAGS)" \
+	  CFLAGS="$(STAGE1_CFLAGS)" \
+	  LDFLAGS="$(STAGE1_LDFLAGS)" \
+	  ../configure \
+	    --prefix="$(R_HOST)" \
+	    --with-x=no \
+	    --with-aqua=no \
+	    --with-readline=no \
+	    --with-jpeglib=no \
+	    --with-cairo=no \
+	    --disable-openmp \
+	    --with-recommended-packages=no \
+	    --enable-R-profiling=no \
+	    --with-pcre2 \
+	    --disable-nls \
+	    --enable-byte-compiled-packages=no \
+	    --enable-long-double=no
 	touch $@
 
 $(BUILD)/state/r-stage1: $(BUILD)/state/r-stage1-configured
@@ -109,7 +97,6 @@ STAGE2_CPPFLAGS += -I$(WASM)/include
 STAGE2_CPPFLAGS += -DEXPEL_OLD_TO_NEW=1
 STAGE2_CPPFLAGS += -s USE_BZIP2=1
 STAGE2_CPPFLAGS += -s USE_ZLIB=1
-STAGE2_CPPFLAGS += -s USE_LIBPNG=1
 
 STAGE2_CFLAGS := $(STAGE2_CFLAGS)
 STAGE2_CFLAGS += $(STAGE2_CPPFLAGS) $(WASM_CFLAGS)
@@ -134,31 +121,32 @@ SHLIB_LDFLAGS  = -s SIDE_MODULE=1
 SHLIB_LDFLAGS += -s WASM_BIGINT $(WASM_OPT_LDADD)
 
 # Stage 2: Reconfigure and build for wasm32-unknown-emscripten target
-$(BUILD)/state/r-stage2-configured: $(BUILD)/state/r-patched $(WASM_LIBS)
+$(BUILD)/state/r-stage2-configured: $(BUILD)/state/r-patched $(FORTRAN_WASM_LIB)
 	mkdir -p $(R_SOURCE)/build
 	cd $(R_SOURCE)/build && \
+	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
 	  MAIN_LDFLAGS="$(MAIN_LDFLAGS)" \
-	    SHLIB_LDFLAGS="$(SHLIB_LDFLAGS)" \
-	    CPPFLAGS="$(STAGE2_CPPFLAGS)" \
-	    CFLAGS="$(STAGE2_CFLAGS)" \
-	    LDFLAGS="$(STAGE2_LDFLAGS)" \
-	    FFLAGS="" \
-	    FPICFLAGS="-fPIC" \
-	    FC="$(EMFC)" \
-	    emconfigure ../configure \
-	      --prefix="$(R_WASM)" \
-	      --with-x=no \
-	      --with-readline=no \
-	      --with-jpeglib=no \
-	      --with-cairo=no \
-	      --disable-openmp \
-	      --with-recommended-packages=no \
-	      --enable-R-profiling=no \
-	      --with-pcre2 \
-	      --disable-nls \
-	      --enable-byte-compiled-packages=no \
-	      --enable-static=yes \
-	      --host=wasm32-unknown-emscripten
+	  SHLIB_LDFLAGS="$(SHLIB_LDFLAGS)" \
+	  CPPFLAGS="$(STAGE2_CPPFLAGS)" \
+	  CFLAGS="$(STAGE2_CFLAGS)" \
+	  LDFLAGS="$(STAGE2_LDFLAGS)" \
+	  FFLAGS="" \
+	  FPICFLAGS="-fPIC" \
+	  FC="$(EMFC)" \
+	  emconfigure ../configure \
+	    --prefix="$(R_WASM)" \
+	    --with-x=no \
+	    --with-readline=no \
+	    --with-jpeglib=no \
+	    --with-cairo=no \
+	    --disable-openmp \
+	    --with-recommended-packages=no \
+	    --enable-R-profiling=no \
+	    --with-pcre2 \
+	    --disable-nls \
+	    --enable-byte-compiled-packages=no \
+	    --enable-static=yes \
+	    --host=wasm32-unknown-emscripten
 # Disable umask which doesn't work well within Emscripten. Fixes
 # permission issues when extracting tarballs.
 	sed -i.bak '/D\["HAVE_UMASK"\]/d' $(R_SOURCE)/build/config.status
@@ -240,47 +228,6 @@ rebuild-modules: $(BUILD)/state/r-stage2
 	  $(MAKE_WASM_BUILD) R && \
 	  $(MAKE_WASM_INSTALL) install-wasm
 	cp -r "$(R_WASM)/dist/." $(DIST)
-
-.PHONY: XZ
-XZ: $(XZ_WASM_LIB)
-
-$(XZ_TARBALL):
-	mkdir -p $(DOWNLOAD)
-	wget $(XZ_URL) -O $@
-
-$(XZ_WASM_LIB): $(XZ_TARBALL)
-	mkdir -p $(BUILD)
-	tar -C $(BUILD) -xf $(XZ_TARBALL)
-	cd $(BUILD)/xz-$(XZ_VERSION) && \
-	  mkdir -p build && \
-	  cd build && \
-	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
-	    --enable-shared=no \
-	    --enable-static=yes \
-	    --prefix=$(WASM) && \
-	  emmake make install
-	touch $@
-
-
-.PHONY: PCRE
-PCRE: $(PCRE_WASM_LIB)
-
-$(PCRE_TARBALL):
-	mkdir -p $(DOWNLOAD)
-	wget -q -O $@ $(PCRE_URL)
-
-$(PCRE_WASM_LIB): $(PCRE_TARBALL)
-	mkdir -p $(BUILD)
-	tar -C $(BUILD) -xf $(PCRE_TARBALL)
-	mkdir -p $(BUILD)/pcre2-$(PCRE_VERSION)/build
-	cd $(BUILD)/pcre2-$(PCRE_VERSION)/build && \
-	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
-	    --enable-shared=no \
-	    --enable-static=yes \
-	    --prefix=$(WASM) && \
-	  emmake make install
-	touch $@
-
 
 .PHONY: clean
 clean:

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -1,0 +1,54 @@
+WEBR_ROOT = $(abspath ..)
+ROOT = $(abspath .)
+
+DOWNLOAD = $(ROOT)/download
+BUILD = $(ROOT)/build
+DIST = $(WEBR_ROOT)/dist
+TOOLS = $(WEBR_ROOT)/tools
+HOST = $(WEBR_ROOT)/host
+WASM = $(WEBR_ROOT)/wasm
+
+
+WASM_OPT ?= -Oz
+WASM_OPT_LDADD ?= $(WASM_OPT)
+
+WASM_CFLAGS := $(WASM_CFLAGS)
+WASM_CFLAGS += -fPIC -fno-exceptions -fno-rtti $(WASM_OPT)
+
+
+LIBPNG_VERSION = 1.6.38
+LIBPNG_TARBALL = $(DOWNLOAD)/libpng-$(LIBPNG_VERSION).tar.gz
+LIBPNG_URL = http://prdownloads.sourceforge.net/libpng/libpng-$(LIBPNG_VERSION).tar.xz?download
+LIBPNG_WASM_LIB = $(WASM)/lib/libpng.a
+
+
+.PHONY: libpng
+libpng: $(LIBPNG_WASM_LIB)
+
+$(LIBPNG_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget $(LIBPNG_URL) -O $@
+
+$(LIBPNG_WASM_LIB): $(LIBPNG_TARBALL)
+	mkdir -p $(BUILD)
+	tar -C $(BUILD) -xf $(LIBPNG_TARBALL)
+	cd $(BUILD)/libpng-$(LIBPNG_VERSION) && \
+	  mkdir -p build && \
+	  cd build && \
+	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --prefix=$(WASM) && \
+	  emmake make install
+	touch $@
+
+
+.PHONY: clean
+clean:
+	rm -rf $(DOWNLOAD) $(BUILD)
+	rm -f $(LIBPNG_WASM_LIB)
+
+
+# Print Makefile variable
+.PHONY: print-%
+print-%  : ; @echo $* = $($*)

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -8,19 +8,31 @@ TOOLS = $(WEBR_ROOT)/tools
 HOST = $(WEBR_ROOT)/host
 WASM = $(WEBR_ROOT)/wasm
 
-
 WASM_OPT ?= -Oz
 WASM_OPT_LDADD ?= $(WASM_OPT)
 
 WASM_CFLAGS := $(WASM_CFLAGS)
 WASM_CFLAGS += -fPIC -fno-exceptions -fno-rtti $(WASM_OPT)
-
+WASM_CFLAGS += -s USE_BZIP2=1 -s USE_ZLIB=1
 
 LIBPNG_VERSION = 1.6.38
 LIBPNG_TARBALL = $(DOWNLOAD)/libpng-$(LIBPNG_VERSION).tar.gz
 LIBPNG_URL = http://prdownloads.sourceforge.net/libpng/libpng-$(LIBPNG_VERSION).tar.xz?download
 LIBPNG_WASM_LIB = $(WASM)/lib/libpng.a
 
+PCRE_VERSION = 10.39
+PCRE_TARBALL = $(DOWNLOAD)/pcre2-$(PCRE_VERSION).tar.gz
+PCRE_URL = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${PCRE_VERSION}/pcre2-$(PCRE_VERSION).tar.gz
+PCRE_WASM_LIB = $(WASM)/lib/libpcre2-8.a
+
+XZ_VERSION = 5.2.5
+XZ_TARBALL = $(DOWNLOAD)/xz-$(XZ_VERSION).tar.gz
+XZ_URL = https://tukaani.org/xz/xz-$(XZ_VERSION).tar.gz/download
+XZ_WASM_LIB = $(WASM)/lib/liblzma.a
+
+WASM_LIBS = $(LIBPNG_WASM_LIB) $(PCRE_WASM_LIB) $(XZ_WASM_LIB)
+
+all: $(WASM_LIBS)
 
 .PHONY: libpng
 libpng: $(LIBPNG_WASM_LIB)
@@ -42,12 +54,49 @@ $(LIBPNG_WASM_LIB): $(LIBPNG_TARBALL)
 	  emmake make install
 	touch $@
 
+.PHONY: pcre2
+pcre2: $(PCRE_WASM_LIB)
+
+$(PCRE_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget -q -O $@ $(PCRE_URL)
+
+$(PCRE_WASM_LIB): $(PCRE_TARBALL)
+	mkdir -p $(BUILD)
+	tar -C $(BUILD) -xf $(PCRE_TARBALL)
+	mkdir -p $(BUILD)/pcre2-$(PCRE_VERSION)/build
+	cd $(BUILD)/pcre2-$(PCRE_VERSION)/build && \
+	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --prefix=$(WASM) && \
+	  emmake make install
+	touch $@
+
+.PHONY: xz
+xz: $(XZ_WASM_LIB)
+
+$(XZ_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget $(XZ_URL) -O $@
+
+$(XZ_WASM_LIB): $(XZ_TARBALL)
+	mkdir -p $(BUILD)
+	tar -C $(BUILD) -xf $(XZ_TARBALL)
+	cd $(BUILD)/xz-$(XZ_VERSION) && \
+	  mkdir -p build && \
+	  cd build && \
+	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --prefix=$(WASM) && \
+	  emmake make install
+	touch $@
 
 .PHONY: clean
 clean:
 	rm -rf $(DOWNLOAD) $(BUILD)
-	rm -f $(LIBPNG_WASM_LIB)
-
+	rm -f $(WASM_LIBS)
 
 # Print Makefile variable
 .PHONY: print-%


### PR DESCRIPTION
So that packages from webr-repo can link to it.

Using `EM_LIBS = -s USE_LIBPNG=1` only works in `CFLAGS` for include files. It is ignored in `LDFLAGS` because Emscripten doesn't link side modules to system libs or ports.

I tried directly linking to ports in the Emscripten cache but this causes compilation issues because the ports are not compiled with `-fPIC`. So unfortunately it looks like we can't use Emscripten ports for CRAN packages, unless we link them in the main lib with `EMCC_FORCE_STDLIBS=` to work around dead-code elimination. However that would increase the binary size even in cases where the libs are not needed.

So instead, this PR adds a `libs` directory to webR to maintain our own ports for system libs. It isn't part of the default build. Instead it should be built manually before running `make` in webr-repo.

Alternatively, we could build several versions of webR with different sets of system libs statically linked in. This would have the advantage of reducing the total size when several packages link to the same lib. But we can think about this when/if this problem comes up.