### PR TITLE
Improve `PKG_BASE_URL` config

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ TS_SOURCES = $(shell find . -name '*.ts' -not -path './node_modules/*')
 -include ~/.webr-config.mk
 
 BASE_URL ?= "./"
+PKG_BASE_URL ?= "https://repo.webr.workers.dev/"
 
 HTML_DIST = $(addprefix $(DIST)/,$(HTML_TEMPLATES))
 $(DIST): $(TS_SOURCES) $(HTML_DIST) \
@@ -22,10 +23,12 @@ $(DIST): $(TS_SOURCES) $(HTML_DIST) \
 	touch $@
 
 $(DIST)/%.html: templates/%.html
-	sed -e "s|@@BASE_URL@@|$(BASE_URL)|" $< > $@
+	sed -e "s|@@BASE_URL@@|$(BASE_URL)|" \
+	  -e "s|@@PKG_BASE_URL@@|$(PKG_BASE_URL)|" $< > $@
 
 webR/config.ts: webR/config.ts.in
-	sed -e "s|@@BASE_URL@@|$(BASE_URL)|" webR/config.ts.in > webR/config.ts
+	sed -e "s|@@BASE_URL@@|$(BASE_URL)|" \
+	  -e "s|@@PKG_BASE_URL@@|$(PKG_BASE_URL)|" webR/config.ts.in > webR/config.ts
 
 .PHONY: check
 check: $(DIST)

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -1,6 +1,5 @@
 import { initFSTree, FSTreeInterface, JSTreeNode } from './fstree';
 import { WebR, FSNode } from '../webR/webr-main';
-import { PKG_BASE_URL } from '../webR/config';
 
 import 'xterm/css/xterm.css';
 import { Terminal } from 'xterm';
@@ -78,7 +77,6 @@ const webR = new WebR({
 
   readline.setCtrlCHandler(() => webR.interrupt());
 
-  webR.evalRCode(`options(webr_pkg_repos="${PKG_BASE_URL}")`);
   webR.evalRCode('webr::global_prompt_install()', undefined, { withHandlers: false });
 
   // Clear the loading message

--- a/src/webR/config.ts.in
+++ b/src/webR/config.ts.in
@@ -1,2 +1,2 @@
 export const BASE_URL = '@@BASE_URL@@';
-export const PKG_BASE_URL = 'https://repo.webr.workers.dev/';
+export const PKG_BASE_URL = '@@PKG_BASE_URL@@';

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -373,6 +373,7 @@ function init(config: Required<WebROptions>) {
     resolveInit: () => {
       chan?.setInterrupt(Module._Rf_onintr);
       Module.setValue(Module._R_Interactive, _config.interactive, '*');
+      evalRCode(`options(webr_pkg_repos="${_config.PKG_URL}")`);
       chan?.resolve();
     },
 


### PR DESCRIPTION
Allow for setting `PKG_BASE_URL` in `~/.webr-config.mk` to set the default package repo.

Set the `webr_pkg_repos` R options setting for all use of webR, rather than just when setting up the REPL app.