### PR TITLE
Rename evalR to captureR, create a simpler version for evalR, re-throw R conditions as exceptions

### DIFF
--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -77,7 +77,7 @@ const webR = new WebR({
 
   readline.setCtrlCHandler(() => webR.interrupt());
 
-  webR.evalR('webr::global_prompt_install()', undefined, { withHandlers: false });
+  webR.captureR('webr::global_prompt_install()', undefined, { withHandlers: false });
 
   // Clear the loading message
   term.write('\x1b[2K\r');

--- a/src/tests/packages/webr.test.ts
+++ b/src/tests/packages/webr.test.ts
@@ -7,11 +7,8 @@ const webR = new WebR({
   interactive: false,
 });
 
-function evalTest(pkg: string) {
-  return webR.evalR(`webr::test_package("${pkg}")`, undefined, {
-    captureConditions: false,
-    captureStreams: false,
-  });
+async function evalTest(pkg: string) {
+  return (await webR.evalR(`webr::test_package("${pkg}")`)) as RDouble;
 }
 
 beforeAll(async () => {
@@ -21,69 +18,69 @@ beforeAll(async () => {
 });
 
 test('The webr R package is installed', async () => {
-  const pkg = (await webR.evalR('"webr" %in% installed.packages()')).result as RLogical;
+  const pkg = (await webR.evalR('"webr" %in% installed.packages()')) as RLogical;
   expect(await pkg.toLogical()).toEqual(true);
 });
 
 describe('Run R default package examples and tests', () => {
   test('datasets', async () => {
-    const test = (await evalTest('datasets')).result as RDouble;
+    const test = await evalTest('datasets');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('tools', async () => {
-    const test = (await evalTest('tools')).result as RDouble;
+    const test = await evalTest('tools');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('utils', async () => {
-    const test = (await evalTest('utils')).result as RDouble;
+    const test = await evalTest('utils');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('grDevices', async () => {
-    const test = (await evalTest('grDevices')).result as RDouble;
+    const test = await evalTest('grDevices');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('graphics', async () => {
-    const test = (await evalTest('graphics')).result as RDouble;
+    const test = await evalTest('graphics');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('stats', async () => {
-    const test = (await evalTest('stats')).result as RDouble;
+    const test = await evalTest('stats');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('stats4', async () => {
-    const test = (await evalTest('stats4')).result as RDouble;
+    const test = await evalTest('stats4');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('splines', async () => {
-    const test = (await evalTest('splines')).result as RDouble;
+    const test = await evalTest('splines');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('methods', async () => {
-    const test = (await evalTest('methods')).result as RDouble;
+    const test = await evalTest('methods');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('compiler', async () => {
-    const test = (await evalTest('compiler')).result as RDouble;
+    const test = await evalTest('compiler');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('base', async () => {
-    const test = (await evalTest('base')).result as RDouble;
+    const test = await evalTest('base');
     expect(await test.toNumber()).toEqual(0);
   });
 
   test('grid', async () => {
     await webR.evalR('options(expressions=5000)');
-    const test = (await evalTest('grid')).result as RDouble;
+    const test = await evalTest('grid');
     expect(await test.toNumber()).toEqual(0);
   });
 });

--- a/src/tests/webR/proxy.test.ts
+++ b/src/tests/webR/proxy.test.ts
@@ -12,12 +12,12 @@ beforeAll(async () => {
 });
 
 test('Evaluate code and return a proxy', async () => {
-  const result = (await webR.evalR('42')).result;
+  const result = await webR.evalR('42');
   expect(util.types.isProxy(result)).toBe(true);
 });
 
 test('RProxy _target property', async () => {
-  const result = (await webR.evalR('42')).result;
+  const result = await webR.evalR('42');
   expect(result._target).toHaveProperty('targetType', 'ptr');
   expect(result._target).toHaveProperty('obj');
   const obj = result._target.obj as { type: string; methods: string[]; ptr: number };
@@ -27,20 +27,20 @@ test('RProxy _target property', async () => {
 });
 
 test('RFunctions can be invoked via the proxy apply hook', async () => {
-  const fn = (await webR.evalR('factorial')).result as RFunction;
+  const fn = (await webR.evalR('factorial')) as RFunction;
   const result = await fn(8);
   expect(result).toEqual(expect.objectContaining({ names: null, values: [40320] }));
 });
 
 test('RFunctions can be returned by R functions and invoked via the apply hook', async () => {
-  const fn = (await webR.evalR('function(x) function (y) {x*y}')).result as RFunction;
+  const fn = (await webR.evalR('function(x) function (y) {x*y}')) as RFunction;
   const invoke = (await fn(5)) as RFunction;
   const result = await invoke(7);
   expect(result).toEqual(expect.objectContaining({ names: null, values: [35] }));
 });
 
 test('R list objects can be iterated over with `for await`', async () => {
-  const list = (await webR.evalR('list(1+2i, "b", TRUE)')).result as RList;
+  const list = (await webR.evalR('list(1+2i, "b", TRUE)')) as RList;
   const result: any[] = [];
   for await (const elem of list) {
     result.push(await elem.toJs());
@@ -54,7 +54,7 @@ test('R list objects can be iterated over with `for await`', async () => {
 
 test('Attempting to iterate over unsupported R objects throws an error', async () => {
   const shouldThrow = async () => {
-    const notalist = (await webR.evalR('as.symbol("notalist")')).result;
+    const notalist = await webR.evalR('as.symbol("notalist")');
     const result: any[] = [];
     for await (const elem of notalist) {
       result.push(await elem.toJs());
@@ -65,7 +65,7 @@ test('Attempting to iterate over unsupported R objects throws an error', async (
 });
 
 test('R atomic vector objects can be iterated over with `for await`', async () => {
-  const vec = (await webR.evalR('c(3, 5, 6, 7, 9, 10, 11, 12, 13)')).result as RList;
+  const vec = (await webR.evalR('c(3, 5, 6, 7, 9, 10, 11, 12, 13)')) as RList;
   const result: any[] = [];
   for await (const elem of vec) {
     const val = await (elem as RDouble).toNumber();

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -26,43 +26,43 @@ beforeAll(async () => {
 });
 
 test('Convert an RNull value to JS', async () => {
-  const result = (await webR.evalR('NULL')).result as RNull;
+  const result = (await webR.evalR('NULL')) as RNull;
   const nullObj = await result.toJs();
   expect(nullObj.type).toEqual('null');
 });
 
 test('Convert an R symbol to JS', async () => {
-  const result = (await webR.evalR('as.symbol("x")')).result as RSymbol;
+  const result = (await webR.evalR('as.symbol("x")')) as RSymbol;
   expect(await (await result.printname()).toJs()).toBe('x');
   expect(await (await result.symvalue()).isUnbound()).toBe(true);
   expect(await (await result.internal()).isNull()).toBe(true);
 });
 
 test('Get RObject type as a string', async () => {
-  const result = (await webR.evalR('NULL')).result as RNull;
+  const result = (await webR.evalR('NULL')) as RNull;
   expect(await result.toString()).toEqual('[object RObj:null]');
 });
 
 describe('Working with R lists and vectors', () => {
   test('Get R object attributes', async () => {
-    const vector = (await webR.evalR('c(a=1, b=2, c=3)')).result;
+    const vector = await webR.evalR('c(a=1, b=2, c=3)');
     const value = (await vector.attrs()) as RList;
     const attrs = await value.toObject({ depth: 0 });
     expect(attrs.names).toEqual(expect.objectContaining({ names: null, values: ['a', 'b', 'c'] }));
   });
 
   test('Get R object names', async () => {
-    let vector = (await webR.evalR('c(a=1, b=2, c=3)')).result;
+    let vector = await webR.evalR('c(a=1, b=2, c=3)');
     let value = await vector.names();
     expect(await value).toEqual(['a', 'b', 'c']);
 
-    vector = (await webR.evalR('c(1, 2, 3)')).result;
+    vector = await webR.evalR('c(1, 2, 3)');
     value = await vector.names();
     expect(await value).toEqual(null);
   });
 
   test('Set R object names', async () => {
-    const vector = (await webR.evalR('c(1, 2, 3)')).result;
+    const vector = await webR.evalR('c(1, 2, 3)');
     await vector.setNames(['d', 'e', 'f']);
     const value = await vector.names();
     expect(await value).toEqual(['d', 'e', 'f']);
@@ -73,7 +73,7 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Get an item with [[ operator', async () => {
-    const vector = (await webR.evalR('list(a=1, b=2, c=3)')).result;
+    const vector = await webR.evalR('list(a=1, b=2, c=3)');
     let value = (await vector.get('b')) as RDouble;
     expect(await value.toNumber()).toEqual(2);
     value = (await vector.get(3)) as RDouble;
@@ -81,7 +81,7 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Get an item with [ operator', async () => {
-    const vector = (await webR.evalR('list(a=1+4i, b=2-5i, c=3+6i)')).result;
+    const vector = await webR.evalR('list(a=1+4i, b=2-5i, c=3+6i)');
     const val1 = (await vector.subset('b')) as RList;
     const obj1 = await val1.toObject({ depth: 0 });
     expect(obj1.b).toEqual(expect.objectContaining({ names: null, values: [{ re: 2, im: -5 }] }));
@@ -92,15 +92,13 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Get an item with $ operator', async () => {
-    const vector = (await webR.evalR('list(a="x", b="y", c="z")')).result;
+    const vector = await webR.evalR('list(a="x", b="y", c="z")');
     const value = (await vector.getDollar('b')) as RCharacter;
     expect(await value.toArray()).toEqual(['y']);
   });
 
   test('Get an item using the pluck method', async () => {
-    const vector = (
-      await webR.evalR('list(a=1, b=list(d="x",e="y",f=list(g=4,h=5,i=c(6,7))), c=3)')
-    ).result;
+    const vector = await webR.evalR('list(a=1, b=list(d="x",e="y",f=list(g=4,h=5,i=c(6,7))), c=3)');
     let value = (await vector.pluck('b', 'f', 'i', 2)) as RDouble;
     expect(await value.toNumber()).toEqual(7);
     value = (await vector.pluck('b', 'f', 'i', 10)) as RDouble;
@@ -108,8 +106,8 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Set an item using the set method', async () => {
-    let vector = (await webR.evalR('c(a=1, b=2, c=3)')).result;
-    const value = (await webR.evalR('4')).result;
+    let vector = await webR.evalR('c(a=1, b=2, c=3)');
+    const value = await webR.evalR('4');
     vector = await vector.set(1, value);
     vector = await vector.set(2, 5);
     vector = await vector.set('c', 6);
@@ -118,13 +116,13 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('R pairlist includes method', async () => {
-    const result = (await webR.evalR('as.pairlist(list(x="a", y="b", z="c"))')).result as RPairlist;
+    const result = (await webR.evalR('as.pairlist(list(x="a", y="b", z="c"))')) as RPairlist;
     expect(await result.includes('x')).toBe(true);
     expect(await result.includes('a')).toBe(false);
   });
 
   test('Convert an R pairlist to JS', async () => {
-    const result = (await webR.evalR('as.pairlist(list(x="a", y="b", z="c"))')).result as RPairlist;
+    const result = (await webR.evalR('as.pairlist(list(x="a", y="b", z="c"))')) as RPairlist;
     const arr = await result.toArray({ depth: 0 });
     expect(arr[0]).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
     expect(arr[1]).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
@@ -141,12 +139,12 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('R list includes method', async () => {
-    const result = (await webR.evalR('list(x="a", y="b", z="c")')).result as RList;
+    const result = (await webR.evalR('list(x="a", y="b", z="c")')) as RList;
     expect(await result.includes('x')).toBe(true);
   });
 
   test('Convert an R list to JS', async () => {
-    const result = (await webR.evalR('list(x="a", y="b", z="c")')).result as RList;
+    const result = (await webR.evalR('list(x="a", y="b", z="c")')) as RList;
     const arr = await result.toArray({ depth: 0 });
     expect(arr[0]).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
     expect(arr[1]).toEqual(expect.objectContaining({ names: null, values: ['b'] }));
@@ -163,9 +161,9 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Fully undefined names attribute', async () => {
-    const list = (await webR.evalR('list("a", "b", "c")')).result as RList;
-    const pairlist = (await webR.evalR('pairlist("a", "b", "c")')).result as RPairlist;
-    const atomic = (await webR.evalR('c("a", "b", "c")')).result as RCharacter;
+    const list = (await webR.evalR('list("a", "b", "c")')) as RList;
+    const pairlist = (await webR.evalR('pairlist("a", "b", "c")')) as RPairlist;
+    const atomic = (await webR.evalR('c("a", "b", "c")')) as RCharacter;
     const listJs = await list.toTree();
     const pairlistJs = await pairlist.toTree();
     const atomicJs = await atomic.toTree();
@@ -175,9 +173,9 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Partially undefined names attribute', async () => {
-    const list = (await webR.evalR('list(x="a", y="b", "c")')).result as RList;
-    const pairlist = (await webR.evalR('pairlist(x="a", y="b", "c")')).result as RPairlist;
-    const atomic = (await webR.evalR('c(x="a", y="b", "c")')).result as RCharacter;
+    const list = (await webR.evalR('list(x="a", y="b", "c")')) as RList;
+    const pairlist = (await webR.evalR('pairlist(x="a", y="b", "c")')) as RPairlist;
+    const atomic = (await webR.evalR('c(x="a", y="b", "c")')) as RCharacter;
     const listJs = await list.toTree();
     const pairlistJs = await pairlist.toTree();
     const atomicJs = await atomic.toTree();
@@ -187,41 +185,42 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Missing values in names attribute', async () => {
-    const list = (await webR.evalR('test = list(1,2); attr(test,"names") <- c("a", NA); test'))
-      .result as RList;
+    const list = (await webR.evalR(
+      'test = list(1,2); attr(test,"names") <- c("a", NA); test'
+    )) as RList;
     const listJs = await list.toTree();
     expect(listJs.names).toEqual(['a', null]);
     await expect(list.toObject()).rejects.toThrow('Empty or null key when converting');
   });
 
   test('Converted object has type property', async () => {
-    const list = (await webR.evalR('list(1,2,3)')).result as RList;
+    const list = (await webR.evalR('list(1,2,3)')) as RList;
     const listJs = await list.toJs();
     expect(listJs.type).toEqual('list');
-    const logical = (await webR.evalR('TRUE')).result as RLogical;
+    const logical = (await webR.evalR('TRUE')) as RLogical;
     const logicalJs = await logical.toJs();
     expect(logicalJs.type).toEqual('logical');
-    const double = (await webR.evalR('c(1,2,3)')).result as RDouble;
+    const double = (await webR.evalR('c(1,2,3)')) as RDouble;
     const doubleJs = await double.toJs();
     expect(doubleJs.type).toEqual('double');
   });
 
   test('First key wins when converting R objects to JS objects', async () => {
-    const list = (await webR.evalR('list(x="a", x="b")')).result as RList;
+    const list = (await webR.evalR('list(x="a", x="b")')) as RList;
     const listObj = await list.toObject({ depth: 0 });
     expect(listObj.x).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
-    const pairlist = (await webR.evalR('pairlist(x="a", x="b")')).result as RPairlist;
+    const pairlist = (await webR.evalR('pairlist(x="a", x="b")')) as RPairlist;
     const pairlistObj = await pairlist.toObject({ depth: 0 });
     expect(pairlistObj.x).toEqual(expect.objectContaining({ names: null, values: ['a'] }));
-    const atomic = (await webR.evalR('c(x="a", x="b")')).result as RCharacter;
+    const atomic = (await webR.evalR('c(x="a", x="b")')) as RCharacter;
     const atomicObj = await atomic.toObject();
     expect(atomicObj.x).toEqual('a');
   });
 
   test('Empty key when converting to JS object', async () => {
-    const list = (await webR.evalR('list(x="a", y="b", "c")')).result as RList;
-    const pairlist = (await webR.evalR('pairlist(x="a", y="b", "c")')).result as RPairlist;
-    const atomic = (await webR.evalR('c(x="a", y="b", "c")')).result as RCharacter;
+    const list = (await webR.evalR('list(x="a", y="b", "c")')) as RList;
+    const pairlist = (await webR.evalR('pairlist(x="a", y="b", "c")')) as RPairlist;
+    const atomic = (await webR.evalR('c(x="a", y="b", "c")')) as RCharacter;
     await expect(list.toObject({ depth: 0 })).rejects.toThrow('Empty or null key when converting');
     await expect(pairlist.toObject({ depth: 0 })).rejects.toThrow(
       'Empty or null key when converting'
@@ -240,20 +239,20 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Throw on duplicate keys when converting R objects to JS objects', async () => {
-    const list = (await webR.evalR('list(x="a", x="b")')).result as RList;
+    const list = (await webR.evalR('list(x="a", x="b")')) as RList;
     const listObj = list.toObject({ allowDuplicateKey: false, depth: 0 });
     await expect(listObj).rejects.toThrow('Duplicate key when converting');
-    const pairlist = (await webR.evalR('pairlist(x="a", x="b")')).result as RPairlist;
+    const pairlist = (await webR.evalR('pairlist(x="a", x="b")')) as RPairlist;
     const pairlistObj = pairlist.toObject({ allowDuplicateKey: false, depth: 0 });
     await expect(pairlistObj).rejects.toThrow('Duplicate key when converting');
-    const atomic = (await webR.evalR('c(x="a", x="b")')).result as RCharacter;
+    const atomic = (await webR.evalR('c(x="a", x="b")')) as RCharacter;
     const atomicObj = atomic.toObject({ allowDuplicateKey: false });
     await expect(atomicObj).rejects.toThrow('Duplicate key when converting');
   });
 
   test('Convert an R double atomic vector to JS', async () => {
     const polytree = [1, 1, 3, 8, 27, 91, 350, 1376];
-    const result = (await webR.evalR('c(1, 1, 3, 8, 27, 91, 350, 1376)')).result as RDouble;
+    const result = (await webR.evalR('c(1, 1, 3, 8, 27, 91, 350, 1376)')) as RDouble;
     const resJs = await result.toJs();
     expect(resJs.values).toEqual(polytree);
     expect(resJs.names).toEqual(null);
@@ -264,8 +263,7 @@ describe('Working with R lists and vectors', () => {
 
   test('Convert an R integer atomic vector to JS', async () => {
     const polytree = [1, 1, 3, 8, 27, 91, 350, 1376];
-    const result = (await webR.evalR('as.integer(c(1, 1, 3, 8, 27, 91, 350, 1376))'))
-      .result as RInteger;
+    const result = (await webR.evalR('as.integer(c(1, 1, 3, 8, 27, 91, 350, 1376))')) as RInteger;
     const resJs = await result.toJs();
     expect(resJs.values).toEqual(polytree);
     expect(resJs.names).toEqual(null);
@@ -276,7 +274,7 @@ describe('Working with R lists and vectors', () => {
 
   test('Convert an R logical atomic vector to JS', async () => {
     const logical = [true, false, null];
-    const result = (await webR.evalR('c(TRUE, FALSE, NA)')).result as RLogical;
+    const result = (await webR.evalR('c(TRUE, FALSE, NA)')) as RLogical;
     const resJs = await result.toJs();
     expect(resJs.values).toEqual(logical);
     expect(resJs.names).toEqual(null);
@@ -287,7 +285,7 @@ describe('Working with R lists and vectors', () => {
 
   test('Convert an R raw atomic vector to JS', async () => {
     const arr = [2, 4, 6];
-    const result = (await webR.evalR('as.raw(c(2, 4, 6))')).result as RRaw;
+    const result = (await webR.evalR('as.raw(c(2, 4, 6))')) as RRaw;
     const resJs = await result.toJs();
     expect(resJs.values).toEqual(arr);
     expect(resJs.names).toEqual(null);
@@ -299,7 +297,7 @@ describe('Working with R lists and vectors', () => {
       { re: 2, im: -7 },
       { re: 1, im: -8 },
     ];
-    const result = (await webR.evalR('c(2-7i, 1-8i)')).result as RComplex;
+    const result = (await webR.evalR('c(2-7i, 1-8i)')) as RComplex;
     const resJs = await result.toJs();
     expect(resJs.values).toEqual(cmplx);
     expect(resJs.names).toEqual(null);
@@ -307,36 +305,36 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Convert an R scalar double to JS number', async () => {
-    const result = (await webR.evalR('1234')).result as RDouble;
+    const result = (await webR.evalR('1234')) as RDouble;
     expect(await result.toNumber()).toEqual(1234);
   });
 
   test('Convert an R scalar integer to JS number', async () => {
-    const result = (await webR.evalR('as.integer(5678)')).result as RInteger;
+    const result = (await webR.evalR('as.integer(5678)')) as RInteger;
     expect(await result.toNumber()).toEqual(5678);
   });
 
   test('Convert an R scalar logical to JS', async () => {
-    let result = (await webR.evalR('TRUE')).result as RLogical;
+    let result = (await webR.evalR('TRUE')) as RLogical;
     expect(await result.toLogical()).toEqual(true);
-    result = (await webR.evalR('FALSE')).result as RLogical;
+    result = (await webR.evalR('FALSE')) as RLogical;
     expect(await result.toLogical()).toEqual(false);
-    result = (await webR.evalR('NA')).result as RLogical;
+    result = (await webR.evalR('NA')) as RLogical;
     expect(await result.toLogical()).toEqual(null);
   });
 
   test('Convert an R scalar raw to JS number', async () => {
-    const result = (await webR.evalR('as.raw(255)')).result as RRaw;
+    const result = (await webR.evalR('as.raw(255)')) as RRaw;
     expect(await result.toNumber()).toEqual(255);
   });
 
   test('Convert an R scalar complex to JS', async () => {
-    const result = (await webR.evalR('c(-3+4i)')).result as RComplex;
+    const result = (await webR.evalR('c(-3+4i)')) as RComplex;
     expect(await result.toComplex()).toEqual({ re: -3, im: 4 });
   });
 
   test('Convert an R pairlist to depth 1', async () => {
-    const result = (await webR.evalR('pairlist(pairlist(1))')).result as RPairlist;
+    const result = (await webR.evalR('pairlist(pairlist(1))')) as RPairlist;
     let convert = await result.toTree();
     expect(isRObject(convert.values[0])).toEqual(false);
     convert = await result.toTree({ depth: 1 });
@@ -344,7 +342,7 @@ describe('Working with R lists and vectors', () => {
   });
 
   test('Convert an R list to depth 1', async () => {
-    const result = (await webR.evalR('list(list(1))')).result as RList;
+    const result = (await webR.evalR('list(list(1))')) as RList;
     let convert = await result.toTree();
     expect(isRObject(convert.values[0])).toEqual(false);
     convert = await result.toTree({ depth: 1 });
@@ -354,12 +352,12 @@ describe('Working with R lists and vectors', () => {
 
 describe('Working with R environments', () => {
   test('Create an R environment', async () => {
-    const env = (await webR.evalR('new.env()')).result as REnvironment;
+    const env = (await webR.evalR('new.env()')) as REnvironment;
     expect(await env.toString()).toEqual('[object RObj:environment]');
   });
 
   test('List items in an R environment', async () => {
-    const env = (await webR.evalR('x<-new.env();x$a=1;x$b=2;x$.c=3;x')).result as REnvironment;
+    const env = (await webR.evalR('x<-new.env();x$a=1;x$b=2;x$.c=3;x')) as REnvironment;
     let ls = await env.ls();
     expect(ls).toEqual(['a', 'b']);
     ls = await env.ls(true);
@@ -369,7 +367,7 @@ describe('Working with R environments', () => {
   });
 
   test('Get an item in an R environment', async () => {
-    const env = (await webR.evalR('x<-new.env();x$a=1;x$b=2;x$.c=3;x')).result as REnvironment;
+    const env = (await webR.evalR('x<-new.env();x$a=1;x$b=2;x$.c=3;x')) as REnvironment;
     let value = (await env.getDollar('a')) as RDouble;
     expect(await value.toNumber()).toEqual(1);
     value = (await env.get('b')) as RDouble;
@@ -379,7 +377,7 @@ describe('Working with R environments', () => {
   });
 
   test('Set an item in an R environment', async () => {
-    const env = (await webR.evalR('new.env()')).result as REnvironment;
+    const env = (await webR.evalR('new.env()')) as REnvironment;
     env.bind('a', 1);
     env.bind('b', 2);
     env.bind('.c', 3);
@@ -392,8 +390,7 @@ describe('Working with R environments', () => {
   });
 
   test('Convert an R environment to JS', async () => {
-    const env = (await webR.evalR('x<-new.env();x$a=TRUE;x$b=FALSE;x$.c=NA;x'))
-      .result as REnvironment;
+    const env = (await webR.evalR('x<-new.env();x$a=TRUE;x$b=FALSE;x$.c=NA;x')) as REnvironment;
     const envJs = await env.toJs();
     expect(envJs.names).toEqual(['.c', 'a', 'b']);
     expect(envJs.values[0]).toEqual(expect.objectContaining({ names: null, values: [null] }));
@@ -406,8 +403,7 @@ describe('Working with R environments', () => {
   });
 
   test('Convert an R environment to depth 1', async () => {
-    const env = (await webR.evalR('x<-new.env();x$a=TRUE;x$b=FALSE;x$.c=NA;x'))
-      .result as REnvironment;
+    const env = (await webR.evalR('x<-new.env();x$a=TRUE;x$b=FALSE;x$.c=NA;x')) as REnvironment;
     let convert = await env.toTree();
     expect(isRObject(convert.values[0])).toEqual(false);
     convert = await env.toTree({ depth: 1 });
@@ -415,40 +411,40 @@ describe('Working with R environments', () => {
   });
 
   test('Evaluating R code in an environment', async () => {
-    const env = (await webR.evalR('x<-new.env();x$a=1;x$b=2;x$.c=3;x')).result as REnvironment;
-    const value = (await webR.evalR('b', env)).result as RDouble;
+    const env = (await webR.evalR('x<-new.env();x$a=1;x$b=2;x$.c=3;x')) as REnvironment;
+    const value = (await webR.evalR('b', env)) as RDouble;
     expect(await value.toNumber()).toEqual(2);
   });
 });
 
 describe('Invoking RFunction objects', () => {
   test('Execute an R function with JS arguments', async () => {
-    const choose = (await webR.evalR('choose')).result as RFunction;
+    const choose = (await webR.evalR('choose')) as RFunction;
     const result = (await choose.exec(7, 5)) as RInteger;
     expect(await result.toNumber()).toBe(21);
   });
 
   test('Execute an R function with RProxy arguments', async () => {
-    const factorial = (await webR.evalR('factorial')).result as RFunction;
-    const four = (await webR.evalR('4')).result;
+    const factorial = (await webR.evalR('factorial')) as RFunction;
+    const four = await webR.evalR('4');
     const result = (await factorial.exec(four)) as RInteger;
     expect(await result.toNumber()).toBe(24);
   });
 
   test('Pass JS booleans as R logical arguments', async () => {
-    const c = (await webR.evalR('c')).result as RFunction;
+    const c = (await webR.evalR('c')) as RFunction;
     const logical = (await c.exec(true, [true, false])) as RLogical;
     expect(await logical.toArray()).toEqual([true, true, false]);
   });
 
   test('Pass JS number as R double arguments', async () => {
-    const c = (await webR.evalR('c')).result as RFunction;
+    const c = (await webR.evalR('c')) as RFunction;
     const double = (await c.exec(3.0, [3.1, 3.14])) as RDouble;
     expect(await double.toArray()).toEqual([3.0, 3.1, 3.14]);
   });
 
   test('Pass JS object as R complex arguments', async () => {
-    const c = (await webR.evalR('c')).result as RFunction;
+    const c = (await webR.evalR('c')) as RFunction;
     const cmplx = (await c.exec({ re: 1, im: 2 }, { re: -3, im: -4 })) as RComplex;
     expect(await cmplx.toArray()).toEqual([
       { re: 1, im: 2 },
@@ -457,7 +453,7 @@ describe('Invoking RFunction objects', () => {
   });
 
   test('Pass JS string as R character arguments', async () => {
-    const c = (await webR.evalR('c')).result as RFunction;
+    const c = (await webR.evalR('c')) as RFunction;
     const cmplx = (await c.exec('Hello', ['World', '!'])) as RComplex;
     expect(await cmplx.toArray()).toEqual(['Hello', 'World', '!']);
   });
@@ -465,11 +461,11 @@ describe('Invoking RFunction objects', () => {
 
 describe('Garbage collection', () => {
   test('Protect and release R objects', async () => {
-    const gc = (await webR.evalR('gc')).result as RFunction;
+    const gc = (await webR.evalR('gc')) as RFunction;
     await gc.exec(false, false, true);
     const before = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 
-    const mem = (await webR.evalR('rnorm(10000,1,1)')).result;
+    const mem = await webR.evalR('rnorm(10000,1,1)');
     mem.preserve();
     const during = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 

--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -1,5 +1,5 @@
 import { WebR } from '../../webR/webr-main';
-import { RInteger, RLogical, RRaw, RList, RCharacter } from '../../webR/robj';
+import { RInteger, RLogical, RRaw } from '../../webR/robj';
 
 const webR = new WebR({
   WEBR_URL: '../dist/',
@@ -13,13 +13,13 @@ beforeAll(async () => {
 describe('Download and install binary webR packages', () => {
   test('Install packages via evalR', async () => {
     await webR.evalR('webr::install("cli", repos="https://repo.webr.workers.dev/")');
-    const pkg = (await webR.evalR('"cli" %in% library(cli)')).result as RLogical;
+    const pkg = (await webR.evalR('"cli" %in% library(cli)')) as RLogical;
     expect(await pkg.toLogical()).toEqual(true);
   });
 
   test('Install packages via API', async () => {
     await webR.installPackages(['MASS']);
-    const pkg = (await webR.evalR('"MASS" %in% library(MASS)')).result as RLogical;
+    const pkg = (await webR.evalR('"MASS" %in% library(MASS)')) as RLogical;
     expect(await pkg.toLogical()).toEqual(true);
   });
 });
@@ -28,7 +28,7 @@ describe('Test webR virtual filesystem', () => {
   const testFileContents = new Uint8Array([1, 2, 4, 7, 11, 16, 22, 29, 37, 46]);
   test('Upload a file to the VFS', async () => {
     await expect(webR.putFileData('/tmp/testFile', testFileContents)).resolves.not.toThrow();
-    const readFile = (await webR.evalR('readBin("/tmp/testFile", "raw", 10)')).result as RRaw;
+    const readFile = (await webR.evalR('readBin("/tmp/testFile", "raw", 10)')) as RRaw;
     expect(Array.from(await readFile.toArray())).toEqual(Array.from(testFileContents));
   });
 
@@ -52,19 +52,13 @@ describe('Test webR virtual filesystem', () => {
 
 describe('Execute JavaScript code from R', () => {
   test('Execute a JS expression', async () => {
-    const res = (await webR.evalR('webr::eval_js("Math.round(Math.sin(24) * 10)")'))
-      .result as RInteger;
+    const res = (await webR.evalR('webr::eval_js("Math.round(Math.sin(24) * 10)")')) as RInteger;
     expect(await res.toNumber()).toEqual(-9);
   });
 
   test('Raise a JS exception as an R condition', async () => {
-    const res = (await webR.evalR('webr::eval_js("51+")')).output as {
-      type: string;
-      data: RList;
-    }[];
-    expect(res[0].type).toEqual('error');
-    const cndMessage = (await res[0].data.get('message')) as RCharacter;
-    expect(await cndMessage.toString()).toContain('Unexpected end of input');
+    const badSyntax = webR.evalR('webr::eval_js("51+")');
+    await expect(badSyntax).rejects.toThrow('Unexpected end of input');
   });
 
   test('Return types are as expected', async () => {
@@ -74,15 +68,15 @@ describe('Execute JavaScript code from R', () => {
      * future so as to return different types.
      */
     // Integers are returned as is
-    const res1 = (await webR.evalR('webr::eval_js("1 + 2")')).result as RInteger;
+    const res1 = (await webR.evalR('webr::eval_js("1 + 2")')) as RInteger;
     expect(await res1.toNumber()).toEqual(3);
 
     // Doubles are truncated to integer
-    const res2 = (await webR.evalR('webr::eval_js("Math.E")')).result as RInteger;
+    const res2 = (await webR.evalR('webr::eval_js("Math.E")')) as RInteger;
     expect(await res2.toNumber()).toEqual(2);
 
     // Other objects are converted to integer 0
-    const res3 = (await webR.evalR('webr::eval_js("\'abc\'")')).result as RInteger;
+    const res3 = (await webR.evalR('webr::eval_js("\'abc\'")')) as RInteger;
     expect(await res3.toNumber()).toEqual(0);
   });
 });

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -19,6 +19,7 @@ export type CaptureROptions = {
   captureStreams?: boolean;
   captureConditions?: boolean;
   withAutoprint?: boolean;
+  throwJsException?: boolean;
   withHandlers?: boolean;
 };
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -15,7 +15,7 @@ import {
   RCharacter,
 } from './robj';
 
-export type EvalROptions = {
+export type CaptureROptions = {
   captureStreams?: boolean;
   captureConditions?: boolean;
   withAutoprint?: boolean;
@@ -111,10 +111,10 @@ export class WebR {
     return (await this.#chan.request({ type: 'getFSNode', data: { path: path } })) as FSNode;
   }
 
-  async evalR(
+  async captureR(
     code: string,
     env?: REnvironment,
-    options: EvalROptions = {}
+    options: CaptureROptions = {}
   ): Promise<{
     result: RObject;
     output: unknown[];
@@ -124,7 +124,7 @@ export class WebR {
     }
 
     const target = (await this.#chan.request({
-      type: 'evalR',
+      type: 'captureR',
       data: {
         code: code,
         env: env?._target,
@@ -160,6 +160,10 @@ export class WebR {
         return { result, output };
       }
     }
+  }
+
+  async evalR(code: string, env?: REnvironment): Promise<RObject> {
+    return (await this.captureR(code, env)).result;
   }
 
   async newRObject(


### PR DESCRIPTION
A new option to `captureR` is also added so that captured R error conditions can be re-thrown as JS exceptions. This setting is on by default.

The unit tests are also updated to reflect the new naming and the way R errors are thrown.