### PR TITLE
Send output to console.log and console.warn during basic evalR use

### DIFF
--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -407,7 +407,34 @@ function captureR(code: string, env?: RTargetPtr, options: CaptureROptions = {})
 }
 
 function evalR(code: string, env?: RTargetPtr): RObjImpl {
-  return captureR(code, env).get('result');
+  const capture = captureR(code, env);
+
+  // Send captured conditions and output to the JS console. By default, captured
+  // error conditions are thrown and so do not need to be handled here.
+  const output = capture.get('output') as RObjList;
+  for (let i = 1; i <= output.length; i++) {
+    const out = output.get(i);
+    const outputType = out.get('type').toString();
+    switch (outputType) {
+      case 'stdout':
+        console.log(out.get('data').toString());
+        break;
+      case 'stderr':
+        console.warn(out.get('data').toString());
+        break;
+      case 'message':
+        console.warn(out.pluck('data', 'message')?.toString() || '');
+        break;
+      case 'warning':
+        console.warn(`Warning message: \n${out.pluck('data', 'message')?.toString() || ''}`);
+        break;
+      default:
+        console.warn(`Output of type ${outputType}:`);
+        console.warn(out.get('data').toJs());
+        break;
+    }
+  }
+  return capture.get('result');
 }
 
 function getFileData(name: string): Uint8Array {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -96,6 +96,30 @@ function dispatch(msg: Message): void {
           }
           break;
         }
+        case 'evalR': {
+          const data = reqMsg.data as {
+            code: string;
+            env?: RTargetPtr;
+          };
+          try {
+            const result = evalR(data.code, data.env);
+            write({
+              obj: {
+                type: result.type(),
+                ptr: result.ptr,
+                methods: RObjImpl.getMethods(result),
+              },
+              targetType: 'ptr',
+            });
+          } catch (_e) {
+            const e = _e as Error;
+            write({
+              targetType: 'err',
+              obj: { name: e.name, message: e.message, stack: e.stack },
+            });
+          }
+          break;
+        }
         case 'newRObject': {
           const data = reqMsg.data as RTargetRaw;
           try {


### PR DESCRIPTION
Since `evalR` now does more than just unwrapping `result`, a new dispatch type is added so that the logging to console of stream output and conditions only needs to be implemented once on the worker side. The `result` value is passed back to the main thread, reproducing the previous behaviour.