### PR TITLE
Move Emscripten libFile patching with `sed` to its own make target in `src/Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,7 @@ EMFC_FILES = $(EMFC) $(FORTRAN_WASM_LIB)
 .PHONY: webr
 webr: $(EMFC_FILES)
 	cd R && $(MAKE) && $(MAKE) install
-	cd src && $(MAKE)
-# Patch R.bin.js to workaround Emscripten issue #14502
-# https://github.com/emscripten-core/emscripten/issues/14502
-	sed -i.bak "s|readAsync(libFile,|readAsync(locateFile(libFile),|" dist/R.bin.js
-	rm dist/R.bin.js.bak
-
+	cd src && $(MAKE) && $(MAKE) patch-libfile
 
 $(EMFC_FILES):
 	cd $(EMFC_DIR) && $(MAKE) && $(MAKE) install

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,16 +31,23 @@ webR/config.ts: webR/config.ts.in
 	  -e "s|@@PKG_BASE_URL@@|$(PKG_BASE_URL)|" webR/config.ts.in > webR/config.ts
 
 .PHONY: check
-check: $(DIST)
+check: $(DIST) patch-libfile
 	npx tsc
 	npx eslint $(TS_SOURCES)
 	NODE_V8_COVERAGE=coverage npx c8 node --experimental-wasm-bigint \
 	  ./node_modules/jest/bin/jest.js --config tests/webr.config.js
 
 .PHONY: check-packages
-check-packages: $(DIST)
+check-packages: $(DIST) patch-libfile
 	npx node --experimental-wasm-bigint ./node_modules/jest/bin/jest.js \
 	--config tests/packages.config.js
+
+.PHONY: patch-libfile
+patch-libfile:
+# Patch R.bin.js to workaround Emscripten issue #14502
+# https://github.com/emscripten-core/emscripten/issues/14502
+	sed -i.bak "s|readAsync(libFile,|readAsync(locateFile(libFile),|" ../dist/R.bin.js
+	rm ../dist/R.bin.js.bak
 
 node_modules: package.json
 	npm ci


### PR DESCRIPTION
The patching `sed` command is moved to its own target in `src/Makefile`, and added to the `make check` prerequisites. This ensures that the R WASM binary is patched for loading dynlibs from other directories before attempting to run webR in node during testing.

This patching command can be removed once the linked Emscripten bug has been fixed.