### PR TITLE
Construct R objects on the main thread by proxying the worker thread's RObjImpl class constructor

### DIFF
--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -158,14 +158,14 @@ describe('Evaluate R code', () => {
 describe('Create R objects using serialised form', () => {
   test('Create an R NULL', async () => {
     const jsObj = { type: 'null' };
-    const rObj = (await webR.newRObject(jsObj)) as RNull;
+    const rObj = (await new webR.RObject(jsObj)) as RNull;
     expect(await rObj.type()).toEqual('null');
     expect(await rObj.toJs()).toEqual({ type: 'null' });
   });
 
   test('Create an atomic vector', async () => {
     const jsObj = { type: 'integer', values: [10, 20, 30], names: ['x', 'y', 'z'] };
-    const rObj = (await webR.newRObject(jsObj)) as RInteger;
+    const rObj = (await new webR.RObject(jsObj)) as RInteger;
     expect(await rObj.type()).toEqual('integer');
     expect(await rObj.toArray()).toEqual([10, 20, 30]);
     expect(await rObj.toJs()).toEqual({
@@ -177,7 +177,7 @@ describe('Create R objects using serialised form', () => {
 
   test('Create a list', async () => {
     const jsObj = { type: 'list', values: [true, 3.14, 'abc'], names: ['x', 'y', 'z'] };
-    const rObj = (await webR.newRObject(jsObj)) as RList;
+    const rObj = (await new webR.RObject(jsObj)) as RList;
     expect(await rObj.type()).toEqual('list');
     const list = await rObj.toJs();
     expect(list.names).toEqual(['x', 'y', 'z']);
@@ -200,7 +200,7 @@ describe('Create R objects using serialised form', () => {
 
   test('Create a pairlist', async () => {
     const jsObj = { type: 'pairlist', values: [true, 3.14, 'abc'], names: ['x', 'y', 'z'] };
-    const rObj = (await webR.newRObject(jsObj)) as RPairlist;
+    const rObj = (await new webR.RObject(jsObj)) as RPairlist;
     expect(await rObj.type()).toEqual('pairlist');
     const list = await rObj.toJs();
     expect(list.names).toEqual(['x', 'y', 'z']);
@@ -223,7 +223,7 @@ describe('Create R objects using serialised form', () => {
 
   test('Create an environment', async () => {
     const jsObj = { type: 'environment', names: ['x', 'y'], values: [123, 'abc'] };
-    const rObj = (await webR.newRObject(jsObj)) as REnvironment;
+    const rObj = (await new webR.RObject(jsObj)) as REnvironment;
     expect(await rObj.type()).toEqual('environment');
     expect(await rObj.ls()).toEqual(['x', 'y']);
     const x = await rObj.get('x');
@@ -245,7 +245,7 @@ describe('Create R objects using serialised form', () => {
 
 describe('Create R atomic vectors from JS arrays', () => {
   test('Convert a JS null to R logical NA', async () => {
-    const rObj = (await webR.newRObject(null)) as RLogical;
+    const rObj = (await new webR.RObject(null)) as RLogical;
     expect(await rObj.type()).toEqual('logical');
     expect(await rObj.toJs()).toEqual(
       expect.objectContaining({
@@ -257,7 +257,7 @@ describe('Create R atomic vectors from JS arrays', () => {
 
   test('Create a logical atomic vector', async () => {
     const jsObj = [true, false, true, null];
-    const rObj = (await webR.newRObject(jsObj)) as RLogical;
+    const rObj = (await new webR.RObject(jsObj)) as RLogical;
     expect(await rObj.type()).toEqual('logical');
     expect(await rObj.toJs()).toEqual(
       expect.objectContaining({
@@ -269,14 +269,14 @@ describe('Create R atomic vectors from JS arrays', () => {
 
   test('Create a double atomic vector', async () => {
     const jsObj = [1, 2, 3, 6, 11, 23, 47, 106, null];
-    const rObj = (await webR.newRObject(jsObj)) as RDouble;
+    const rObj = (await new webR.RObject(jsObj)) as RDouble;
     expect(await rObj.type()).toEqual('double');
     expect(await rObj.toArray()).toEqual(jsObj);
   });
 
   test('Create a character atomic vector', async () => {
     const jsObj = ['a', 'b', 'c', null];
-    const rObj = (await webR.newRObject(jsObj)) as RCharacter;
+    const rObj = (await new webR.RObject(jsObj)) as RCharacter;
     expect(await rObj.type()).toEqual('character');
     expect(await rObj.toJs()).toEqual(
       expect.objectContaining({
@@ -288,7 +288,7 @@ describe('Create R atomic vectors from JS arrays', () => {
 
   test('Create a complex atomic vector', async () => {
     const jsObj = [{ re: 1, im: 2 }, { re: -3, im: -4 }, null];
-    const rObj = (await webR.newRObject(jsObj)) as RComplex;
+    const rObj = (await new webR.RObject(jsObj)) as RComplex;
     expect(await rObj.type()).toEqual('complex');
     expect(await rObj.toJs()).toEqual(
       expect.objectContaining({
@@ -305,8 +305,8 @@ describe('Serialise nested R lists, pairlists and vectors unambiguously', () => 
       'list(a=list(e=c(T,F,NA),f=c(1,2,3)), b=pairlist(g=c(4L,5L,6L)), c=list(h=c("abc","def"), i=list(7i)))'
     )) as RList;
     const jsObj = await rObj.toTree();
-    const newRObj = (await webR.newRObject(jsObj)) as RList;
-    const env = (await webR.newRObject({
+    const newRObj = (await new webR.RObject(jsObj)) as RList;
+    const env = (await new webR.RObject({
       type: 'environment',
       names: ['newRObj', 'rObj'],
       values: [newRObj, rObj],
@@ -321,8 +321,8 @@ describe('Serialise nested R lists, pairlists and vectors unambiguously', () => 
       'list(a=list(e=c(T,F,NA),f=c(1,2,3)), b=pairlist(g=c(4L,5L,6L)), c=list(h=c("abc","def"), i=list(7i)))'
     )) as RList;
     const jsObj = await rObj.toTree({ depth: 1 });
-    const newRObj = (await webR.newRObject(jsObj)) as RList;
-    const env = (await webR.newRObject({
+    const newRObj = (await new webR.RObject(jsObj)) as RList;
+    const env = (await new webR.RObject({
       type: 'environment',
       names: ['newRObj', 'rObj'],
       values: [newRObj, rObj],

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -13,7 +13,7 @@ type Methods<T> = {
  *
  * Distributes RProxy over any RObjImpls in the given union type U.
  */
-type DistProxy<U> = U extends RObjImpl
+export type DistProxy<U> = U extends RObjImpl
   ? RProxy<U>
   : U extends RObjectTree<RObjImpl>
   ? RObjectTree<RObject>

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -1,7 +1,7 @@
 import { newChannelMain, ChannelMain, ChannelType } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
-import { newRProxy } from './proxy';
+import { newRProxy, DistProxy } from './proxy';
 import { unpackScalarVectors, replaceInObject } from './utils';
 import {
   RTargetObj,
@@ -9,10 +9,10 @@ import {
   isRObject,
   RawType,
   RList,
-  RObjectTree,
-  NamedObject,
   REnvironment,
   RCharacter,
+  RObjData,
+  RObjImpl,
 } from './robj';
 
 export type CaptureROptions = {
@@ -60,12 +60,16 @@ const defaultOptions = {
   channelType: ChannelType.Automatic,
 };
 
+type RData = DistProxy<RObjData>;
 export class WebR {
   #chan: ChannelMain;
+  RObject;
 
   constructor(options: WebROptions = {}) {
     const config: Required<WebROptions> = Object.assign(defaultOptions, options);
     this.#chan = newChannelMain(config);
+
+    this.RObject = this.#newRObjConstructor<RData | RData[], RObject>();
   }
 
   async init() {
@@ -188,13 +192,18 @@ export class WebR {
     }
   }
 
-  async newRObject(
-    jsObj: RawType | RawType[] | RObjectTree<RObject> | NamedObject<RawType | RObject>
-  ): Promise<RObject> {
-    const targetObj = replaceInObject(jsObj, isRObject, (obj: RObject) => obj._target);
+  #newRObjConstructor<T, R>() {
+    return new Proxy(RObjImpl, {
+      construct: (_, args: [unknown]) => this.#newRObject(...args),
+    }) as unknown as {
+      new (arg: T): Promise<R>;
+    };
+  }
+
+  async #newRObject(value: unknown): Promise<RObject> {
     const target = (await this.#chan.request({
       type: 'newRObject',
-      data: { targetType: 'raw', obj: targetObj },
+      data: replaceInObject(value, isRObject, (obj: RObject) => obj._target),
     })) as RTargetObj;
     switch (target.targetType) {
       case 'raw':

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -61,6 +61,7 @@ const defaultOptions = {
 };
 
 type RData = DistProxy<RObjData>;
+
 export class WebR {
   #chan: ChannelMain;
   RObject;


### PR DESCRIPTION
This PR tweaks the syntax for how new R objects are created on the main thread. Rather than using `webR.newRObject([...])`, the R object class is proxied on `webR` and the constructor function is hooked as part of the proxy. Construction is intercepted and converted into a `newRObject` message to be sent to the worker thread.

The result is that new R objects are more explicitly created using the syntax,
```
const obj = await new webR.RObject([...])
```

The `await` is a little strange but required due to the communication channel.

Creating a new R object is otherwise similar to before this PR, where serialised `RObjectTree` types are converted to the relevant R object type, and JS arrays are converted into R atomic vectors according to the rules of R's `c()` function.

This change is partial progress towards #112 in which this scheme is expanded so that different types of R object types can be constructed on the main thread, by exposing the different R object class constructors through proxies.