### PR TITLE
Construct R objects of specific type on the main thread by proxying further R object class constructors

### DIFF
--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -9,7 +9,6 @@ import {
   RList,
   RPairlist,
   REnvironment,
-  RNull,
   RInteger,
 } from '../../webR/robj';
 
@@ -158,7 +157,7 @@ describe('Evaluate R code', () => {
 describe('Create R objects using serialised form', () => {
   test('Create an R NULL', async () => {
     const jsObj = { type: 'null' };
-    const rObj = (await new webR.RObject(jsObj)) as RNull;
+    const rObj = await new webR.RObject(jsObj);
     expect(await rObj.type()).toEqual('null');
     expect(await rObj.toJs()).toEqual({ type: 'null' });
   });
@@ -301,7 +300,7 @@ describe('Create R vectors from JS arrays using RObject constructor', () => {
 
 describe('Create R objects from JS objects using proxy constructors', () => {
   test('Create an R NULL', async () => {
-    const rObj = await new webR.RNull();
+    const rObj = await new webR.RObject({ type: 'null' });
     expect(await rObj.type()).toEqual('null');
     expect(await rObj.isNull()).toEqual(true);
   });
@@ -379,7 +378,7 @@ describe('Create R objects from JS objects using proxy constructors', () => {
   });
 
   test('Create a list containing both a logical NA and R NULL', async () => {
-    const rNull = await new webR.RNull();
+    const rNull = await new webR.RObject({ type: 'null' });
     const jsObj = [true, 2, null, rNull];
     const rObj = await new webR.RList(jsObj);
     expect(await rObj.type()).toEqual('list');
@@ -417,7 +416,7 @@ describe('Create R objects from JS objects using proxy constructors', () => {
   });
 
   test('Create a pairlist containing both a logical NA and R NULL', async () => {
-    const rNull = await new webR.RNull();
+    const rNull = await new webR.RObject({ type: 'null' });
     const jsObj = [true, 2, null, rNull];
     const rObj = await new webR.RPairlist(jsObj);
     expect(await rObj.type()).toEqual('pairlist');

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -85,7 +85,7 @@ export type RTargetObj = RTargetRaw | RTargetPtr | RTargetError;
 
 type Nullable<T> = T | RObjNull;
 
-type Complex = {
+export type Complex = {
   re: number;
   im: number;
 };
@@ -109,7 +109,7 @@ export type NamedEntries<T> = [string | null, T][];
 export type NamedObject<T> = { [key: string]: T };
 
 export type RObjData = RObjImpl | RawType | RObjectTree<RObjImpl>;
-export type RObjAtomicData<T> = T | (T | null)[] | RObjectTreeAtomic<T>;
+export type RObjAtomicData<T> = T | (T | null)[] | RObjectTreeAtomic<T> | NamedObject<T | null>;
 export type RObjectTree<T> = RObjectTreeImpl<(RObjectTree<T> | RawType | T)[]>;
 export type RObjectTreeAtomic<T> = RObjectTreeImpl<(T | null)[]>;
 type RObjectTreeImpl<T> = {
@@ -482,7 +482,7 @@ export class RObjSymbol extends RObjImpl {
 }
 
 export class RObjPairlist extends RObjImpl {
-  constructor(val: RawType | (RawType | null)[] | RTargetPtr | RObjectTree<RTargetObj>) {
+  constructor(val: RawType | RObjectTree<RTargetObj> | NamedObject<RTargetObj | RawType>) {
     if (isRTargetObj(val)) {
       super(val);
       return this;
@@ -577,7 +577,7 @@ export class RObjPairlist extends RObjImpl {
 }
 
 export class RObjList extends RObjImpl {
-  constructor(val: RawType | (RawType | null)[] | RTargetPtr | RObjectTree<RTargetObj>) {
+  constructor(val: RawType | RObjectTree<RTargetObj> | NamedObject<RTargetObj | RawType>) {
     if (isRTargetObj(val)) {
       super(val);
       return this;
@@ -678,7 +678,7 @@ export class RObjString extends RObjImpl {
 }
 
 export class RObjEnvironment extends RObjImpl {
-  constructor(val: RTargetPtr | RObjectTree<RTargetObj>) {
+  constructor(val: RTargetPtr | RObjectTree<RTargetObj> | NamedObject<RTargetObj | RawType>) {
     if (isRTargetObj(val)) {
       super(val);
       return this;

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -142,11 +142,11 @@ function newRObjFromTarget(target: RTargetObj): RObjImpl {
   if (typeof obj === 'number') {
     return new RObjDouble(obj);
   }
-  if (typeof obj === 'object' && 're' in obj && 'im' in obj) {
-    return new RObjComplex(obj as Complex);
-  }
   if (typeof obj === 'string') {
     return new RObjCharacter(obj);
+  }
+  if (isComplex(obj)) {
+    return new RObjComplex(obj);
   }
 
   // JS arrays are interpreted using R's c() function, so as to match
@@ -1170,6 +1170,16 @@ export function isRObjectTree(value: any): value is RObjectTree<any> {
   );
 }
 
+/**
+ * Test if an object is of type Complex
+ *
+ * @param {any} value The object to test.
+ * @return {boolean} True if the object is of type Complex.
+ */
+export function isComplex(value: any): value is Complex {
+  return value && typeof value === 'object' && 're' in value && 'im' in value;
+}
+
 export function getRObjClass(type: RTypeNumber): typeof RObjImpl {
   const typeClasses: { [key: number]: typeof RObjImpl } = {
     [RTypeMap.null]: RObjNull,
@@ -1209,11 +1219,7 @@ function toRObjData(jsObj: RObjData): RObjData {
     return jsObj;
   } else if (Array.isArray(jsObj)) {
     return { names: null, values: jsObj };
-  } else if (
-    jsObj !== null &&
-    typeof jsObj === 'object' &&
-    Object.keys(jsObj).some((k) => !(k === 're' || k === 'im'))
-  ) {
+  } else if (jsObj && typeof jsObj === 'object' && !isComplex(jsObj)) {
     return {
       names: Object.keys(jsObj),
       values: Object.values(jsObj),

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -487,7 +487,7 @@ export class RObjPairlist extends RObjImpl {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     const list = RObjImpl.wrap(Module._Rf_allocList(values.length)) as RObjPairlist;
     list.preserve();
     for (
@@ -497,7 +497,7 @@ export class RObjPairlist extends RObjImpl {
     ) {
       next.setcar(new RObjImpl(values[i]));
     }
-    list.setNames(isRObjectTree(val) ? val.names : null);
+    list.setNames(names);
     super({ targetType: 'ptr', obj: { ptr: list.ptr } });
   }
 
@@ -582,12 +582,12 @@ export class RObjList extends RObjImpl {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     const ptr = Module._Rf_protect(Module._Rf_allocVector(RTypeMap.list, values.length));
     values.forEach((v, i) => {
       Module._SET_VECTOR_ELT(ptr, i, new RObjImpl(v).ptr);
     });
-    RObjImpl.wrap(ptr).setNames(isRObjectTree(val) ? val.names : null);
+    RObjImpl.wrap(ptr).setNames(names);
     Module._Rf_unprotect(1);
     Module._R_PreserveObject(ptr);
     super({ targetType: 'ptr', obj: { ptr } });
@@ -683,9 +683,10 @@ export class RObjEnvironment extends RObjImpl {
       super(val);
       return this;
     }
+    const { names, values } = toRObjData(val);
     const ptr = Module._Rf_protect(Module._R_NewEnv(RObjImpl.globalEnv.ptr, 0, 0));
-    val.values.forEach((v, i) => {
-      const name = val.names ? val.names[i] : null;
+    values.forEach((v, i) => {
+      const name = names ? names[i] : null;
       if (!name) {
         throw new Error('Unable to create object in new environment with empty symbol name');
       }
@@ -844,13 +845,13 @@ export class RObjLogical extends RObjAtomicVector<boolean> {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     const ptr = Module._Rf_protect(Module._Rf_allocVector(RTypeMap.logical, values.length));
     const data = Module._LOGICAL(ptr);
     values.forEach((v, i) =>
       Module.setValue(data + 4 * i, v === null ? RObjImpl.naLogical : Boolean(v), 'i32')
     );
-    RObjImpl.wrap(ptr).setNames(isRObjectTree(val) ? val.names : null);
+    RObjImpl.wrap(ptr).setNames(names);
     Module._Rf_unprotect(1);
     Module._R_PreserveObject(ptr);
     super({ targetType: 'ptr', obj: { ptr } });
@@ -888,13 +889,13 @@ export class RObjInteger extends RObjAtomicVector<number> {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     const ptr = Module._Rf_protect(Module._Rf_allocVector(RTypeMap.integer, values.length));
     const data = Module._INTEGER(ptr);
     values.forEach((v, i) =>
       Module.setValue(data + 4 * i, v === null ? RObjImpl.naInteger : Math.round(Number(v)), 'i32')
     );
-    RObjImpl.wrap(ptr).setNames(isRObjectTree(val) ? val.names : null);
+    RObjImpl.wrap(ptr).setNames(names);
     Module._Rf_unprotect(1);
     Module._R_PreserveObject(ptr);
     super({ targetType: 'ptr', obj: { ptr } });
@@ -927,13 +928,13 @@ export class RObjDouble extends RObjAtomicVector<number> {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     const ptr = Module._Rf_protect(Module._Rf_allocVector(RTypeMap.double, values.length));
     const data = Module._REAL(ptr);
     values.forEach((v, i) =>
       Module.setValue(data + 8 * i, v === null ? RObjImpl.naDouble : v, 'double')
     );
-    RObjImpl.wrap(ptr).setNames(isRObjectTree(val) ? val.names : null);
+    RObjImpl.wrap(ptr).setNames(names);
     Module._Rf_unprotect(1);
     Module._R_PreserveObject(ptr);
     super({ targetType: 'ptr', obj: { ptr } });
@@ -963,7 +964,7 @@ export class RObjComplex extends RObjAtomicVector<Complex> {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     const ptr = Module._Rf_protect(Module._Rf_allocVector(RTypeMap.complex, values.length));
     const data = Module._COMPLEX(ptr);
     values.forEach((v, i) =>
@@ -972,7 +973,7 @@ export class RObjComplex extends RObjAtomicVector<Complex> {
     values.forEach((v, i) =>
       Module.setValue(data + 8 * (2 * i + 1), v === null ? RObjImpl.naDouble : v.im, 'double')
     );
-    RObjImpl.wrap(ptr).setNames(isRObjectTree(val) ? val.names : null);
+    RObjImpl.wrap(ptr).setNames(names);
     Module._Rf_unprotect(1);
     Module._R_PreserveObject(ptr);
     super({ targetType: 'ptr', obj: { ptr } });
@@ -1012,7 +1013,7 @@ export class RObjCharacter extends RObjAtomicVector<string> {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     const ptr = Module._Rf_protect(Module._Rf_allocVector(RTypeMap.character, values.length));
     values.forEach((v, i) => {
       if (v === null) {
@@ -1023,7 +1024,7 @@ export class RObjCharacter extends RObjAtomicVector<string> {
         Module._free(str);
       }
     });
-    RObjImpl.wrap(ptr).setNames(isRObjectTree(val) ? val.names : null);
+    RObjImpl.wrap(ptr).setNames(names);
     Module._Rf_unprotect(1);
     Module._R_PreserveObject(ptr);
     super({ targetType: 'ptr', obj: { ptr } });
@@ -1062,14 +1063,14 @@ export class RObjRaw extends RObjAtomicVector<number> {
       super(val);
       return this;
     }
-    const values = isRObjectTree(val) ? val.values : Array.isArray(val) ? val : [val];
+    const { names, values } = toRObjData(val);
     if (values.some((v) => v === null || v > 255 || v < 0)) {
       throw new Error('Cannot create new RRaw object');
     }
     const ptr = Module._Rf_protect(Module._Rf_allocVector(RTypeMap.raw, values.length));
     const data = Module._RAW(ptr);
     values.forEach((v, i) => Module.setValue(data + i, Number(v), 'i8'));
-    RObjImpl.wrap(ptr).setNames(isRObjectTree(val) ? val.names : null);
+    RObjImpl.wrap(ptr).setNames(names);
     Module._Rf_unprotect(1);
     Module._R_PreserveObject(ptr);
     super({ targetType: 'ptr', obj: { ptr } });
@@ -1193,4 +1194,30 @@ export function getRObjClass(type: RTypeNumber): typeof RObjImpl {
     return typeClasses[type];
   }
   return RObjImpl;
+}
+
+/*
+ * Convert the various types possible in the type union RObjData into
+ * consistently typed arrays of names and values.
+ */
+function toRObjData<T>(jsObj: RObjAtomicData<T>): {
+  names: (string | null)[] | null;
+  values: (T | null)[];
+};
+function toRObjData(jsObj: RObjData): RObjData {
+  if (isRObjectTree(jsObj)) {
+    return jsObj;
+  } else if (Array.isArray(jsObj)) {
+    return { names: null, values: jsObj };
+  } else if (
+    jsObj !== null &&
+    typeof jsObj === 'object' &&
+    Object.keys(jsObj).some((k) => !(k === 're' || k === 'im'))
+  ) {
+    return {
+      names: Object.keys(jsObj),
+      values: Object.values(jsObj),
+    };
+  }
+  return { names: null, values: [jsObj] };
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -3,17 +3,9 @@ import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy, DistProxy } from './proxy';
 import { unpackScalarVectors, replaceInObject } from './utils';
-import {
-  RTargetObj,
-  RObject,
-  isRObject,
-  RawType,
-  RList,
-  REnvironment,
-  RCharacter,
-  RObjData,
-  RObjImpl,
-} from './robj';
+import { Complex, RObject, RObjImpl, RList, RPairlist, REnvironment } from './robj';
+import { RType, RCharacter, RLogical, RInteger, RDouble, RComplex, RRaw, RNull } from './robj';
+import { RObjAtomicData, RTargetObj, isRObject, RawType, RObjData, NamedObject } from './robj';
 
 export type CaptureROptions = {
   captureStreams?: boolean;
@@ -65,12 +57,32 @@ type RData = DistProxy<RObjData>;
 export class WebR {
   #chan: ChannelMain;
   RObject;
+  RNull;
+  RLogical;
+  RInteger;
+  RDouble;
+  RCharacter;
+  RComplex;
+  RRaw;
+  RList;
+  RPairlist;
+  REnvironment;
 
   constructor(options: WebROptions = {}) {
     const config: Required<WebROptions> = Object.assign(defaultOptions, options);
     this.#chan = newChannelMain(config);
 
-    this.RObject = this.#newRObjConstructor<RData | RData[], RObject>();
+    this.RObject = this.#newRObjConstructor<RData | RData[], RObject>('object');
+    this.RNull = this.#newRObjConstructor<void, RNull>('null');
+    this.RLogical = this.#newRObjConstructor<RObjAtomicData<boolean>, RLogical>('logical');
+    this.RInteger = this.#newRObjConstructor<RObjAtomicData<number>, RInteger>('integer');
+    this.RDouble = this.#newRObjConstructor<RObjAtomicData<number>, RDouble>('double');
+    this.RComplex = this.#newRObjConstructor<RObjAtomicData<Complex>, RComplex>('complex');
+    this.RCharacter = this.#newRObjConstructor<RObjAtomicData<string>, RCharacter>('character');
+    this.RRaw = this.#newRObjConstructor<RObjAtomicData<number>, RRaw>('raw');
+    this.RList = this.#newRObjConstructor<RData[] | NamedObject<RData>, RList>('list');
+    this.RPairlist = this.#newRObjConstructor<RData[] | NamedObject<RData>, RPairlist>('pairlist');
+    this.REnvironment = this.#newRObjConstructor<NamedObject<RData>, REnvironment>('environment');
   }
 
   async init() {

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -193,18 +193,21 @@ export class WebR {
     }
   }
 
-  #newRObjConstructor<T, R>() {
+  #newRObjConstructor<T, R>(objType: RType | 'object') {
     return new Proxy(RObjImpl, {
-      construct: (_, args: [unknown]) => this.#newRObject(...args),
+      construct: (_, args: [unknown]) => this.#newRObject(objType, ...args),
     }) as unknown as {
       new (arg: T): Promise<R>;
     };
   }
 
-  async #newRObject(value: unknown): Promise<RObject> {
+  async #newRObject(objType: RType | 'object', value: unknown): Promise<RObject> {
     const target = (await this.#chan.request({
       type: 'newRObject',
-      data: replaceInObject(value, isRObject, (obj: RObject) => obj._target),
+      data: {
+        objType,
+        obj: replaceInObject(value, isRObject, (obj: RObject) => obj._target),
+      },
     })) as RTargetObj;
     switch (target.targetType) {
       case 'raw':

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -4,7 +4,7 @@ import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy, DistProxy } from './proxy';
 import { unpackScalarVectors, replaceInObject } from './utils';
 import { Complex, RObject, RObjImpl, RList, RPairlist, REnvironment } from './robj';
-import { RType, RCharacter, RLogical, RInteger, RDouble, RComplex, RRaw, RNull } from './robj';
+import { RType, RCharacter, RLogical, RInteger, RDouble, RComplex, RRaw } from './robj';
 import { RObjAtomicData, RTargetObj, isRObject, RawType, RObjData, NamedObject } from './robj';
 
 export type CaptureROptions = {
@@ -57,7 +57,6 @@ type RData = DistProxy<RObjData>;
 export class WebR {
   #chan: ChannelMain;
   RObject;
-  RNull;
   RLogical;
   RInteger;
   RDouble;
@@ -73,7 +72,6 @@ export class WebR {
     this.#chan = newChannelMain(config);
 
     this.RObject = this.#newRObjConstructor<RData | RData[], RObject>('object');
-    this.RNull = this.#newRObjConstructor<void, RNull>('null');
     this.RLogical = this.#newRObjConstructor<RObjAtomicData<boolean>, RLogical>('logical');
     this.RInteger = this.#newRObjConstructor<RObjAtomicData<number>, RInteger>('integer');
     this.RDouble = this.#newRObjConstructor<RObjAtomicData<number>, RDouble>('double');

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -7,6 +7,8 @@ import { IN_NODE } from './compat';
 import { replaceInObject, throwUnreachable } from './utils';
 import {
   RPtr,
+  RType,
+  RTypeMap,
   isRObjImpl,
   RObjImpl,
   RTargetObj,
@@ -14,6 +16,7 @@ import {
   RawType,
   RTargetRaw,
   RObjList,
+  getRObjClass,
 } from './robj';
 
 let initialised = false;
@@ -121,9 +124,14 @@ function dispatch(msg: Message): void {
           break;
         }
         case 'newRObject': {
-          const data = reqMsg.data as RTargetRaw;
+          const data = reqMsg.data as {
+            obj: RTargetRaw;
+            objType: RType | 'object';
+          };
           try {
-            const res = new RObjImpl(data);
+            const RObjClass =
+              data.objType === 'object' ? RObjImpl : getRObjClass(RTypeMap[data.objType]);
+            const res = new RObjClass(data.obj);
             write({
               obj: {
                 type: res.type(),


### PR DESCRIPTION
Includes #111.

The aim of this PR is to make available several R object constructors on the main thread, for creating specific types of R object from potentially ambiguous JS objects.

The following R object constructors are proxied and exposed on the main thread, in the same way as the `RObjImpl` constructor is exposed as `webR.RObject` in (#111):
 - `RNull`
 - `RLogical`, `RInteger`, `RDouble`, `RComplex`, `RCharacter`, `RRaw`
 - `RList`, `RPairlist`
 - `REnvironment`

In addition, several R object constructor functions on the worker thread have been tweaked so that they can additionally accept objects of the type e.g. `NamedObject<X>`. This type corresponds to JavaScript objects with keys of type `string` and values of type `X`.

This change allows for specific types of R object to be created from the main thread, without having to know about automatic coercion or type mapping rules built into webR or R itself.

Invoking a specific R type constructor in this way feels much more robust than my previous attempts to handle conversion of ambiguous items (such as JS objects) into R objects. For example, with this change either an R list or vector can be created from a JS object, with named values, from the main thread, by invoking the relevant proxied R object constructor.

```
const list = await new webR.RList({ a: 1, b: 2, c: 3 });
const arr = await new webR.RInteger({ a: 1, b: 2, c: 3 });
```

Since we know in advance that `webR.RList` returns an object of type `list`, the calling user also no longer needs to add the type information for TypeScript with `as RList`, unlike when using the current method with `webR.newRObject()` which always returns a generic `RObject`.

The previous `webR.newRObject()` behaviour still exists via the `webR.RObject` constructor. For this, the result does not have a specific associated R object type and its type is encoded as the dummy R type named 'object' in the message to the worker thread. The worker thread detects 'object' and invokes the generic `RObjImpl` constructor in that case.

It is my intention that `webR.RObject` remains as a constructor that automatically "does the right thing", and it is the constructor that should be used when creating objects from serialised form (e.g. from the result of `toJs()`). As with before this change, it also accepts JS scalars and arrays to create an atomic vector of type according to the rules of `c()`. JS objects are not accepted in `webR.RObject`, even though they now work in other constructors, because as previously discussed we might use the JS object syntax for automatically converting into data frames in the future.

WIP: The typing around R tree objects needs to be tweaked to be more consistent and support serialising other R types. This will be done in a separate PR.
