### PR TITLE
Reorganise the `RObjTree` type, used for serialising R objects

### DIFF
--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -33,7 +33,7 @@ test('Convert an RNull value to JS', async () => {
 
 test('Convert an R symbol to JS', async () => {
   const result = (await webR.evalR('as.symbol("x")')) as RSymbol;
-  expect(await (await result.printname()).toJs()).toBe('x');
+  expect(await (await result.printname()).toString()).toBe('x');
   expect(await (await result.symvalue()).isUnbound()).toBe(true);
   expect(await (await result.internal()).isNull()).toBe(true);
 });

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -104,9 +104,14 @@ export function targetMethod(chan: ChannelMain, prop: string): any;
 export function targetMethod(chan: ChannelMain, prop: string, target: RTargetPtr): any;
 export function targetMethod(chan: ChannelMain, prop: string, target?: RTargetPtr): any {
   return async (..._args: unknown[]) => {
-    const args = Array.from({ length: _args.length }, (_, idx) => {
-      const arg = _args[idx];
-      return isRObject(arg) ? arg._target : { obj: arg, targetType: 'raw' };
+    const args = _args.map((arg) => {
+      if (isRObject(arg)) {
+        return arg._target;
+      }
+      return {
+        obj: replaceInObject(arg, isRObject, (obj: RObject) => obj._target),
+        targetType: 'raw',
+      };
     });
 
     const reply = (await chan.request({

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -1,4 +1,4 @@
-import { RTargetPtr, isRObject, RTargetObj, RObjectTree, RObject, RType } from './robj';
+import { RTargetPtr, isRObject, RTargetObj, RObjTreeNode, RObject, RType } from './robj';
 import { RObjImpl, RObjFunction, RawType, isRFunction, isRTargetPtr } from './robj';
 import { ChannelMain } from './chan/channel';
 import { replaceInObject } from './utils';
@@ -15,8 +15,8 @@ type Methods<T> = {
  */
 export type DistProxy<U> = U extends RObjImpl
   ? RProxy<U>
-  : U extends RObjectTree<RObjImpl>
-  ? RObjectTree<RObject>
+  : U extends RObjTreeNode
+  ? RObjTreeNode<RObject>
   : U;
 
 /** Convert an RObjImpl property type to a corresponding RProxy property type

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -108,22 +108,72 @@ export type RawType =
 export type NamedEntries<T> = [string | null, T][];
 export type NamedObject<T> = { [key: string]: T };
 
-export type RObjData = RObjImpl | RawType | RObjectTree<RObjImpl>;
-export type RObjAtomicData<T> = T | (T | null)[] | RObjectTreeAtomic<T> | NamedObject<T | null>;
-export type RObjectTree<T> = RObjectTreeImpl<(RObjectTree<T> | RawType | T)[]>;
-export type RObjectTreeAtomic<T> = RObjectTreeImpl<(T | null)[]>;
-type RObjectTreeImpl<T> = {
-  type: RType;
+/**
+ * RObjData is a union of the JavaScript types that are able to be converted
+ * into an R object.
+ *
+ * RObjData is used both as a general input argument for R object construction
+ * and also as a general return type when converting R objects into JavaScript.
+ *
+ * The type parameter, T, chooses how references to R objects are implemented.
+ * This is required because there are different ways to represent a reference to
+ * an R object in webR. Instances of the RObjImpl class are used on the worker
+ * thread, while proxies of type RObject with a target of type RTargetObj are
+ * used on the main thread. Conversion between the reference types is handled
+ * automatically during proxy communication.
+ */
+export type RObjData<T = RObjImpl> = RawType | T | RObjTree<T> | { [key: string]: RObjData<T> };
+
+/**
+ * A subset of {@link RObjData} for JavaScript objects that can be converted
+ * into R atomic vectors. The parameter T is the JavaScript scalar type
+ * associated with the vector.
+ */
+export type RObjAtomicData<T> = T | (T | null)[] | RObjTreeAtomic<T> | NamedObject<T | null>;
+
+/**
+ * RObjTree is a union of types forming a tree structure, used when serialising
+ * R objects into a JavaScript respresentation.
+ *
+ * Nested R objects are serialised using the RObjTreeNode type, forming branches
+ * in the resulting tree structure, with leaves formed by the remaining types.
+ */
+export type RObjTree<T = RObjImpl> =
+  | RObjTreeNull
+  | RObjTreeString
+  | RObjTreeSymbol
+  | RObjTreeNode<T>
+  | RObjTreeAtomic<atomicType>;
+
+export type RObjTreeNull = {
+  type: 'null';
+};
+export type RObjTreeString = {
+  type: 'string';
+  value: string;
+};
+export type RObjTreeSymbol = {
+  type: 'symbol';
+  printname: string | null;
+  symvalue: RPtr | null;
+  internal: RPtr | null;
+};
+export type RObjTreeNode<T = RObjImpl> = {
+  type: 'list' | 'pairlist' | 'environment';
   names: (string | null)[] | null;
-  values: T;
-  missing?: boolean[];
+  values: (RawType | T | RObjTree<T>)[];
+};
+export type RObjTreeAtomic<T> = {
+  type: 'logical' | 'integer' | 'double' | 'complex' | 'character' | 'raw';
+  names: (string | null)[] | null;
+  values: (T | null)[];
 };
 
 function newRObjFromTarget(target: RTargetObj): RObjImpl {
   const obj = target.obj;
 
-  // Conversion of RObjectTree type JS objects
-  if (isRObjectTree(obj)) {
+  // Conversion of RObjTree type JS objects
+  if (isRObjTree(obj)) {
     return new (getRObjClass(RTypeMap[obj.type]))(obj);
   }
 
@@ -268,7 +318,7 @@ export class RObjImpl {
     return names && names.includes(name);
   }
 
-  toTree(options: ToTreeOptions = { depth: 0 }, depth = 1): RawType | RObjectTree<RObjImpl> {
+  toTree(options: ToTreeOptions = { depth: 0 }, depth = 1): RObjTree {
     throw new Error('This R object cannot be converted to JS');
   }
 
@@ -468,14 +518,20 @@ export class RObjNull extends RObjImpl {
     return this;
   }
 
-  toTree(): { type: 'null' } {
+  toTree(): RObjTreeNull {
     return { type: 'null' };
   }
 }
 
 export class RObjSymbol extends RObjImpl {
-  toTree(): RawType {
-    return this.isUnbound() ? null : this.toObject();
+  toTree(): RObjTreeSymbol {
+    const obj = this.toObject();
+    return {
+      type: 'symbol',
+      printname: obj.printname,
+      symvalue: obj.symvalue,
+      internal: obj.internal,
+    };
   }
 
   toObject(): {
@@ -502,7 +558,7 @@ export class RObjSymbol extends RObjImpl {
 }
 
 export class RObjPairlist extends RObjImpl {
-  constructor(val: RawType | RObjectTree<RTargetObj> | NamedObject<RTargetObj | RawType>) {
+  constructor(val: RTargetObj | RObjData<RTargetObj>) {
     if (isRTargetObj(val)) {
       super(val);
       return this;
@@ -552,10 +608,10 @@ export class RObjPairlist extends RObjImpl {
     return obj.values.map((v, i) => [obj.names ? obj.names[i] : null, v]);
   }
 
-  toTree(options: ToTreeOptions = { depth: 0 }, depth = 1): RObjectTree<RObjImpl> {
+  toTree(options: ToTreeOptions = { depth: 0 }, depth = 1): RObjTreeNode {
     const namesArray: string[] = [];
     let hasNames = false;
-    const values: (RawType | RObjImpl | RObjectTree<RObjImpl>)[] = [];
+    const values: RObjTreeNode['values'] = [];
 
     for (let next = this as Nullable<RObjPairlist>; !next.isNull(); next = next.cdr()) {
       const symbol = next.tag();
@@ -572,7 +628,7 @@ export class RObjPairlist extends RObjImpl {
       }
     }
     const names = hasNames ? namesArray : null;
-    return { type: this.type(), names, values };
+    return { type: 'pairlist', names, values };
   }
 
   includes(name: string): boolean {
@@ -597,7 +653,7 @@ export class RObjPairlist extends RObjImpl {
 }
 
 export class RObjList extends RObjImpl {
-  constructor(val: RawType | RObjectTree<RTargetObj> | NamedObject<RTargetObj | RawType>) {
+  constructor(val: RTargetObj | RObjData<RTargetObj>) {
     if (isRTargetObj(val)) {
       super(val);
       return this;
@@ -644,9 +700,9 @@ export class RObjList extends RObjImpl {
     return obj.values.map((v, i) => [obj.names ? obj.names[i] : null, v]);
   }
 
-  toTree(options: { depth: number } = { depth: 0 }, depth = 1): RObjectTree<RObjImpl> {
+  toTree(options: { depth: number } = { depth: 0 }, depth = 1): RObjTreeNode {
     return {
-      type: this.type(),
+      type: 'list',
       names: this.names(),
       values: [...Array(this.length).keys()].map((i) => {
         if (options.depth && depth >= options.depth) {
@@ -692,13 +748,16 @@ export class RObjString extends RObjImpl {
     return Module.UTF8ToString(Module._R_CHAR(this.ptr));
   }
 
-  toTree(): string {
-    return this.toString();
+  toTree(): RObjTreeString {
+    return {
+      type: 'string',
+      value: this.toString(),
+    };
   }
 }
 
 export class RObjEnvironment extends RObjImpl {
-  constructor(val: RTargetPtr | RObjectTree<RTargetObj> | NamedObject<RTargetObj | RawType>) {
+  constructor(val: RTargetObj | RObjData<RTargetObj>) {
     if (isRTargetObj(val)) {
       super(val);
       return this;
@@ -751,7 +810,7 @@ export class RObjEnvironment extends RObjImpl {
     return this.getDollar(prop);
   }
 
-  toObject({ depth = 0 } = {}): NamedObject<RawType | RObjImpl | RObjectTree<RObjImpl>> {
+  toObject({ depth = 0 } = {}): NamedObject<RObjData> {
     const symbols = this.names();
     return Object.fromEntries(
       [...Array(symbols.length).keys()].map((i) => {
@@ -760,7 +819,7 @@ export class RObjEnvironment extends RObjImpl {
     );
   }
 
-  toTree(options: { depth: number } = { depth: 0 }, depth = 1): RObjectTree<RObjImpl> {
+  toTree(options: { depth: number } = { depth: 0 }, depth = 1): RObjTreeNode {
     const names = this.names();
     const values = [...Array(names.length).keys()].map((i) => {
       if (options.depth && depth >= options.depth) {
@@ -771,7 +830,7 @@ export class RObjEnvironment extends RObjImpl {
     });
 
     return {
-      type: this.type(),
+      type: 'environment',
       names,
       values,
     };
@@ -850,9 +909,9 @@ abstract class RObjAtomicVector<T extends atomicType> extends RObjImpl {
     return values.map((v, i) => [names ? names[i] : null, v]);
   }
 
-  toTree(): RObjectTreeAtomic<T> {
+  toTree(): RObjTreeAtomic<T> {
     return {
-      type: this.type(),
+      type: this.type() as 'logical' | 'integer' | 'double' | 'complex' | 'character' | 'raw',
       names: this.names(),
       values: this.toArray(),
     };
@@ -1176,18 +1235,13 @@ export function isRFunction(value: any): value is RFunction {
 }
 
 /**
- * Test for an RObjectTree instance
+ * Test for an RObjTree instance
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is an instance of an RObjectTree.
+ * @return {boolean} True if the object is an instance of an RObjTree.
  */
-export function isRObjectTree(value: any): value is RObjectTree<any> {
-  return (
-    value &&
-    typeof value === 'object' &&
-    (Array.isArray(value.names) || value.names === null) &&
-    Object.keys(RTypeMap).includes(value.type as string)
-  );
+export function isRObjTree(value: any): value is RObjTree<any> {
+  return value && typeof value === 'object' && Object.keys(RTypeMap).includes(value.type as string);
 }
 
 /**
@@ -1234,8 +1288,9 @@ function toRObjData<T>(jsObj: RObjAtomicData<T>): {
   names: (string | null)[] | null;
   values: (T | null)[];
 };
+function toRObjData(jsObj: RObjData): RObjData;
 function toRObjData(jsObj: RObjData): RObjData {
-  if (isRObjectTree(jsObj)) {
+  if (isRObjTree(jsObj)) {
     return jsObj;
   } else if (Array.isArray(jsObj)) {
     return { names: null, values: jsObj };

--- a/src/webR/utils.ts
+++ b/src/webR/utils.ts
@@ -1,5 +1,4 @@
 import { IN_NODE } from './compat';
-import { RawType } from './robj';
 
 export type ResolveFn = (_value?: unknown) => void;
 export type RejectFn = (_reason?: any) => void;
@@ -42,17 +41,6 @@ export function replaceInObject(
   return Object.fromEntries(
     Object.entries(obj).map(([k, v], i) => [k, replaceInObject(v, test, replacer, ...replacerArgs)])
   );
-}
-
-export function unpackScalarVectors(obj: RawType) {
-  return replaceInObject(
-    obj,
-    (obj: any) =>
-      'values' in obj &&
-      (Array.isArray(obj.values) || ArrayBuffer.isView(obj)) &&
-      obj.values.length === 1,
-    (obj: any) => obj.values[0]
-  ) as RawType;
 }
 
 /* Workaround for loading a cross-origin script.

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -2,9 +2,10 @@ import { newChannelMain, ChannelMain, ChannelType } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy, newRObjClassProxy } from './proxy';
-import { Complex, RObject, RList, RPairlist, REnvironment, RObjAtomicData } from './robj';
-import { RCharacter, RLogical, RInteger, RDouble, RComplex, RRaw, RString } from './robj';
-import { RTargetObj, isRObject, RNull, RObjData, NamedObject } from './robj';
+import { RObject, RTargetObj, isRObject, RObjImpl, RNull, RList, RPairlist, RRaw } from './robj';
+import { REnvironment, RCharacter, RLogical, RInteger, RDouble, RComplex, RString } from './robj';
+import { RObjEnvironment, RObjInteger, RObjComplex, RObjPairlist, RObjList, RObjRaw } from './robj';
+import { RObjDouble, RObjLogical, RObjCharacter } from './robj';
 
 export type CaptureROptions = {
   captureStreams?: boolean;
@@ -51,8 +52,6 @@ const defaultOptions = {
   channelType: ChannelType.Automatic,
 };
 
-type RData = RObjData<RObject>;
-
 export class WebR {
   #chan: ChannelMain;
   RObject;
@@ -78,16 +77,16 @@ export class WebR {
     const config: Required<WebROptions> = Object.assign(defaultOptions, options);
     const ch = (this.#chan = newChannelMain(config));
 
-    this.RObject = newRObjClassProxy<RData | RData[], RObject>(ch, 'object');
-    this.RLogical = newRObjClassProxy<RObjAtomicData<boolean>, RLogical>(ch, 'logical');
-    this.RInteger = newRObjClassProxy<RObjAtomicData<number>, RInteger>(ch, 'integer');
-    this.RDouble = newRObjClassProxy<RObjAtomicData<number>, RDouble>(ch, 'double');
-    this.RComplex = newRObjClassProxy<RObjAtomicData<Complex>, RComplex>(ch, 'complex');
-    this.RCharacter = newRObjClassProxy<RObjAtomicData<string>, RCharacter>(ch, 'character');
-    this.RRaw = newRObjClassProxy<RObjAtomicData<number>, RRaw>(ch, 'raw');
-    this.RList = newRObjClassProxy<RData[] | NamedObject<RData>, RList>(ch, 'list');
-    this.RPairlist = newRObjClassProxy<RData[] | NamedObject<RData>, RPairlist>(ch, 'pairlist');
-    this.REnvironment = newRObjClassProxy<NamedObject<RData>, REnvironment>(ch, 'environment');
+    this.RObject = newRObjClassProxy<typeof RObjImpl, RObject>(ch, 'object');
+    this.RLogical = newRObjClassProxy<typeof RObjLogical, RLogical>(ch, 'logical');
+    this.RInteger = newRObjClassProxy<typeof RObjInteger, RInteger>(ch, 'integer');
+    this.RDouble = newRObjClassProxy<typeof RObjDouble, RDouble>(ch, 'double');
+    this.RComplex = newRObjClassProxy<typeof RObjComplex, RComplex>(ch, 'complex');
+    this.RCharacter = newRObjClassProxy<typeof RObjCharacter, RCharacter>(ch, 'character');
+    this.RRaw = newRObjClassProxy<typeof RObjRaw, RRaw>(ch, 'raw');
+    this.RList = newRObjClassProxy<typeof RObjList, RList>(ch, 'list');
+    this.RPairlist = newRObjClassProxy<typeof RObjPairlist, RPairlist>(ch, 'pairlist');
+    this.REnvironment = newRObjClassProxy<typeof RObjEnvironment, REnvironment>(ch, 'environment');
     this.objs = {} as typeof this.objs;
   }
 

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -287,9 +287,11 @@ function callRObjMethod(
 
   const res = (fn as Function).apply(
     obj,
-    Array.from({ length: args.length }, (_, idx) => {
-      const arg = args[idx];
-      return arg.targetType === 'ptr' ? RObjImpl.wrap(arg.obj.ptr) : arg.obj;
+    args.map((arg) => {
+      if (arg.targetType === 'ptr') {
+        return RObjImpl.wrap(arg.obj.ptr);
+      }
+      return replaceInObject(arg.obj, isRTargetPtr, (t: RTargetPtr) => RObjImpl.wrap(t.obj.ptr));
     })
   ) as RawType | RObjImpl;
 

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -10,6 +10,7 @@ import {
   RType,
   RTypeMap,
   isRObjImpl,
+  isRTargetPtr,
   RObjImpl,
   RTargetObj,
   RTargetPtr,
@@ -129,17 +130,7 @@ function dispatch(msg: Message): void {
             objType: RType | 'object';
           };
           try {
-            const RObjClass =
-              data.objType === 'object' ? RObjImpl : getRObjClass(RTypeMap[data.objType]);
-            const res = new RObjClass(data.obj);
-            write({
-              obj: {
-                type: res.type(),
-                ptr: res.ptr,
-                methods: RObjImpl.getMethods(res),
-              },
-              targetType: 'ptr',
-            });
+            write(newRObject(data.obj, data.objType));
           } catch (_e) {
             const e = _e as Error;
             write({
@@ -242,6 +233,30 @@ function downloadFileContent(URL: string, headers: Array<string> = []): XHRRespo
   } catch {
     return { status: 400, response: 'An error occured in XMLHttpRequest' };
   }
+}
+
+/**
+ * Construct a new R object from a given JavaScript object.
+ *
+ * @param {RawType} target A JavaScript raw target object to be used when
+ * constructing the new R object.
+ * @param {RType | 'object'} objType The type of R object to create, or 'object'
+ * to infer the R object type.
+ * @return {RTargetPtr} The newly created R object, given as a target object.
+ */
+function newRObject(target: RTargetRaw, objType: RType | 'object'): RTargetPtr {
+  const RObjClass = objType === 'object' ? RObjImpl : getRObjClass(RTypeMap[objType]);
+  const obj = new RObjClass(
+    replaceInObject(target, isRTargetPtr, (t: RTargetPtr) => RObjImpl.wrap(t.obj.ptr)) as RTargetRaw
+  );
+  return {
+    obj: {
+      type: obj.type(),
+      ptr: obj.ptr,
+      methods: RObjImpl.getMethods(obj),
+    },
+    targetType: 'ptr',
+  };
 }
 
 /**


### PR DESCRIPTION
This PR is mostly concerned with typing and tidying up the R object construction changes from before the holidays.

The `RObjTree` type is reorganised and expanded to better support different types of R object. The different serialised forms for R NULL, string, symbol and atomic vector types are formalised, and the naming for the types making up the `RObjTree` union is tidied up. Adding types to the system for other serialised R objects should be simpler after this change.

By hard setting the particular strings in the type property, TypeScript can now better infer what properties are available for R objects serialised with functions such as `toTree()`, and better understands how objects are nested using the `RObjTreeNode` type.

Typedoc documentation is added explaining the meaning of the `RObjTree` and `RObjData` types, and how R object references are handled on the main and worker threads by a type parameter.

Handling the R object construction message type on the worker thread is abstracted out into it's own function.

Finally, a certain utility function is no longer required after some cleanup, and so has been removed.