### PR TITLE
Add R object cache to main thread for long-living R objects

### DIFF
--- a/src/webR/module.ts
+++ b/src/webR/module.ts
@@ -92,6 +92,7 @@ export interface Module extends EmscriptenModule {
   _R_NaInt: RPtr;
   _R_NaReal: RPtr;
   _R_NaString: RPtr;
+  _R_LogicalNAValue: RPtr;
   _R_NilValue: RPtr;
   _R_TrueValue: RPtr;
   _R_NamesSymbol: RPtr;

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -69,10 +69,11 @@ function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RObjImpl>) {
   return async function* () {
     // Get the R object's length
     const reply = (await chan.request({
-      type: 'getRObjProperty',
+      type: 'callRObjMethod',
       data: {
         target: proxy._target,
-        prop: 'length',
+        prop: 'getPropertyValue',
+        args: [{ targetType: 'raw', obj: 'length' }],
       },
     })) as RTargetObj;
 
@@ -95,8 +96,13 @@ function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RObjImpl>) {
 
 /* Proxy an R object method by providing an async function that requests that
  * the worker thread calls the method and then returns the result.
+ *
+ * When the optional target argument has not been provided, a RObjImpl static
+ * method is called.
  */
-function targetMethod(chan: ChannelMain, target: RTargetPtr, prop: string) {
+export function targetMethod(chan: ChannelMain, prop: string): any;
+export function targetMethod(chan: ChannelMain, prop: string, target: RTargetPtr): any;
+export function targetMethod(chan: ChannelMain, prop: string, target?: RTargetPtr): any {
   return async (..._args: unknown[]) => {
     const args = Array.from({ length: _args.length }, (_, idx) => {
       const arg = _args[idx];
@@ -166,7 +172,7 @@ export function newRProxy(chan: ChannelMain, target: RTargetPtr): RProxy<RObjImp
         } else if (prop === Symbol.asyncIterator) {
           return targetAsyncIterator(chan, proxy);
         } else if (target.obj.methods?.includes(prop.toString())) {
-          return targetMethod(chan, target, prop.toString());
+          return targetMethod(chan, prop.toString(), target);
         }
       },
       apply: async (_: RTargetObj, _thisArg, args: (RawType | RProxy<RObjImpl>)[]) => {
@@ -181,7 +187,12 @@ export function newRProxy(chan: ChannelMain, target: RTargetPtr): RProxy<RObjImp
 export function newRObjClassProxy<T, R>(chan: ChannelMain, objType: RType | 'object') {
   return new Proxy(RObjImpl, {
     construct: (_, args: [unknown]) => newRObject(chan, objType, ...args),
+    get: (_, prop: string | number | symbol) => {
+      return targetMethod(chan, prop.toString());
+    },
   }) as unknown as {
     new (arg: T): Promise<R>;
+  } & {
+    [P in Methods<typeof RObjImpl>]: RProxify<typeof RObjImpl[P]>;
   };
 }

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -198,8 +198,8 @@ export class RObjImpl {
     return RObjImpl[prop];
   }
 
-  getPropertyValue(prop: string): unknown {
-    return this[prop as keyof typeof this];
+  getPropertyValue(prop: keyof this): unknown {
+    return this[prop];
   }
 
   type(): RType {
@@ -402,6 +402,18 @@ export class RObjImpl {
 
   static get naString(): RObjImpl {
     return RObjImpl.wrap(Module.getValue(Module._R_NaString, '*'));
+  }
+
+  static get true(): RObjLogical {
+    return RObjImpl.wrap(Module.getValue(Module._R_TrueValue, '*')) as RObjLogical;
+  }
+
+  static get false(): RObjLogical {
+    return RObjImpl.wrap(Module.getValue(Module._R_FalseValue, '*')) as RObjLogical;
+  }
+
+  static get logicalNA(): RObjLogical {
+    return RObjImpl.wrap(Module.getValue(Module._R_LogicalNAValue, '*')) as RObjLogical;
   }
 
   static get unboundValue(): RObjImpl {

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -194,6 +194,14 @@ export class RObjImpl {
     return `RObj:${this.type()}`;
   }
 
+  static getStaticPropertyValue(prop: keyof typeof RObjImpl): unknown {
+    return RObjImpl[prop];
+  }
+
+  getPropertyValue(prop: string): unknown {
+    return this[prop as keyof typeof this];
+  }
+
   type(): RType {
     const typeNumber = Module._TYPEOF(this.ptr) as RTypeNumber;
     const type = Object.keys(RTypeMap).find(

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -337,8 +337,8 @@ function captureR(code: string, env?: RTargetPtr, options: CaptureROptions = {})
       }
     }
 
-    const tPtr = Module.getValue(Module._R_TrueValue, '*');
-    const fPtr = Module.getValue(Module._R_FalseValue, '*');
+    const tPtr = RObjImpl.true.ptr;
+    const fPtr = RObjImpl.false.ptr;
     const codeStr = Module.allocateUTF8(code);
     const evalStr = Module.allocateUTF8('webr::eval_r');
     const codeObj = new RObjImpl({ targetType: 'raw', obj: code });


### PR DESCRIPTION
A continuation of #112.

The R object class proxying function, now named `newRObjClassProxy`, has been expanded to enable transfer of static properties of `RObjImpl`. This is done by adding a `getStaticPropertyValue()` static method to `RObjImpl` and tweaking the `callRObjMethod` request type to optionally invoke static methods. The function is also moved to the `proxy.ts` file as part of the change, so as to match where the similar R object instance proxying function, `newRProxy`, lives.

(Note: I considered proxying the static properties directly, but this way better matches the R object instance proxies where only methods are hooked, to avoid potentially confusing situations where it's not clear that requesting a property with `obj.foo` does something complicated and must be `await`ed.)

A similar `getPropertyValue()` method is also added to `RObjImpl`, replacing the need for a separate `getRObjProperty` request type containing mostly repeated code and only used in one place, which has now been removed.

The new feature is used to create an R object cache on the main thread at `webR.objs`. Objects that are constant for the duration of the session (e.g. R's `NULL`) can be added to this cache at init time by grabbing them from static methods on the `RObjImpl` class, where properties such as `RObjImpl.null` already existed.

I have added a few objects to get things started: `NULL`, `TRUE`, `FALSE`, logical `NA`, the base env, and the global env. I'm happy to add any others if there are obvious but missing R objects here.

I really like that this allows for neat tricks such as easily accessing base env symbols,
```
> const ver = await webR.objs.baseEnv.pluck('R.version', 'version.string');
> await ver.toString()
< 'R version 4.1.3 (2022-03-10)'
```
or binding variables to the global environment from JS in one line,
```
await webR.objs.globalEnv.bind('abc', 123);
```

This also provides another way to clearly differentiate between `NULL` and logical `NA` when constructing lists,
```
const list = await new webR.RList([webR.objs.na, webR.objs.null])
```