### PR TITLE
Safety improvements to `captureR()` and `evalR()`

### DIFF
--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -41,11 +41,13 @@ type XHRResponse = {
 const Module = {} as Module;
 let _config: Required<WebROptions>;
 
-interface DictStrings {
-  [key: string]: ReturnType<typeof Module.allocateUTF8>;
+type EmPtr = ReturnType<typeof Module.allocateUTF8>;
+
+interface DictEmPtrs {
+  [key: string]: EmPtr;
 }
-function stringsFree(strings: DictStrings) {
-  Object.keys(strings).forEach((key) => Module._free(strings[key]));
+function dictEmFree(dict: { [key: string | number]: EmPtr }) {
+  Object.keys(dict).forEach((key) => Module._free(dict[key]));
 }
 
 function dispatch(msg: Message): void {
@@ -291,7 +293,7 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
     of protect and ensure a balanced unprotect is called using try-finally.
   */
   let nProt = 0;
-  const strings: DictStrings = {};
+  const strings: DictEmPtrs = {};
 
   try {
     const _options: Required<CaptureROptions> = Object.assign(
@@ -352,7 +354,7 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
 
     return capture;
   } finally {
-    stringsFree(strings);
+    dictEmFree(strings);
     Module._Rf_unprotect(nProt);
   }
 }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -41,6 +41,13 @@ type XHRResponse = {
 const Module = {} as Module;
 let _config: Required<WebROptions>;
 
+interface DictStrings {
+  [key: string]: ReturnType<typeof Module.allocateUTF8>;
+}
+function stringsFree(strings: DictStrings) {
+  Object.keys(strings).forEach((key) => Module._free(strings[key]));
+}
+
 function dispatch(msg: Message): void {
   switch (msg.type) {
     case 'request': {
@@ -284,7 +291,7 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
     of protect and ensure a balanced unprotect is called using try-finally.
   */
   let nProt = 0;
-  const strings: { [key: string]: number } = {};
+  const strings: DictStrings = {};
 
   try {
     const _options: Required<CaptureROptions> = Object.assign(
@@ -345,8 +352,8 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
 
     return capture;
   } finally {
+    stringsFree(strings);
     Module._Rf_unprotect(nProt);
-    Object.keys(strings).forEach((key) => Module._free(strings[key]));
   }
 }
 

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -306,11 +306,14 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
 
     const tPtr = RObject.true.ptr;
     const fPtr = RObject.false.ptr;
+
     const codeStr = Module.allocateUTF8(code);
     const evalStr = Module.allocateUTF8('webr::eval_r');
+
     const codeObj = new RObject({ payloadType: 'raw', obj: code });
     Module._Rf_protect(codeObj.ptr);
     protectCount++;
+
     const expr = Module._Rf_lang6(
       Module._R_ParseEvalString(evalStr, RObject.baseEnv.ptr),
       codeObj.ptr,
@@ -319,8 +322,12 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
       _options.withAutoprint ? tPtr : fPtr,
       _options.withHandlers ? tPtr : fPtr
     );
-    const capture = RObject.wrap(Module._Rf_protect(Module._Rf_eval(expr, envObj.ptr))) as RList;
+
+    const capturePtr = Module._Rf_eval(expr, envObj.ptr);
+    Module._Rf_protect(capturePtr);
     protectCount++;
+
+    const capture = RObject.wrap(capturePtr) as RList;
     Module._free(codeStr);
     Module._free(evalStr);
 


### PR DESCRIPTION
- Protect the result of `captureR()` in `evalR()` before calling `get()` which allocates.
- Deallocate C strings in `finally` clause of `captureR()` to avoid leaks.
- New helper type `DictStrings` to help with the above.
- Some style improvements (paragraphs, shorter name for `nProt`, use of prefix `++` instead of postfix to more easily see the side effect).