### PR TITLE
Use idiomatic cleanup-unwind and env introspection

### DIFF
--- a/packages/webr/R/eval.R
+++ b/packages/webr/R/eval.R
@@ -17,8 +17,12 @@
 #'
 #' @export
 #' @useDynLib webr, .registration = TRUE
-eval_r <- function(code, conditions = TRUE, streams = FALSE, autoprint = FALSE,
-                   handlers = TRUE) {
+eval_r <- function(code,
+                   conditions = TRUE,
+                   streams = FALSE,
+                   autoprint = FALSE,
+                   handlers = TRUE,
+                   env = parent.frame()) {
   res <- NULL
 
   # The following C routine prepares an output object that is used to capture
@@ -54,13 +58,18 @@ eval_r <- function(code, conditions = TRUE, streams = FALSE, autoprint = FALSE,
   # if requested, otherwise just `parse` and `eval` the code.
   if (autoprint) {
     efun <- function(code) {
-      withAutoprint(parse(text = code),
-        local = parent.frame(2), echo = FALSE,
+      out <- withAutoprint(
+        parse(text = code),
+        local = env,
+        echo = FALSE,
         evaluated = TRUE
-      )$value
+      )
+      out$value
     }
   } else {
-    efun <- function(code) eval.parent(parse(text = code), 2)
+    efun <- function(code) {
+      eval(parse(text = code), env)
+    }
   }
 
   if (handlers) {

--- a/packages/webr/R/utils.R
+++ b/packages/webr/R/utils.R
@@ -1,0 +1,8 @@
+on_exit <- function(expr, env = parent.frame()) {
+  args <- list(
+    substitute(expr),
+    add = TRUE,
+    after = FALSE
+  )
+  do.call("on.exit", args, envir = env)
+}


### PR DESCRIPTION
- Add `on_exit()` wrapper of `on.exit()` that sets `add = TRUE, after = FALSE` for safe registration of dtors. Use `on_exit()` to clean up more safely.

- Take `env = parent.frame()` and use that. We generally prefer taking the direct caller env as soon as possible, save it in a variable, and then use that, rather than taking indirect caller envs with a number of frames to skip. The latter is more brittle to changes in the code.