### PR TITLE
Tweaks to how length 1 atomic vectors are converted to JS scalars

### DIFF
--- a/src/tests/packages/webr.test.ts
+++ b/src/tests/packages/webr.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
 
 test('The webr R package is installed', async () => {
   const pkg = (await webR.evalR('"webr" %in% installed.packages()')) as RLogical;
-  expect(await pkg.toLogical()).toEqual(true);
+  expect(await pkg.toBoolean()).toEqual(true);
 });
 
 describe('Run R default package examples and tests', () => {

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -316,11 +316,11 @@ describe('Working with R lists and vectors', () => {
 
   test('Convert an R scalar logical to JS', async () => {
     let result = (await webR.evalR('TRUE')) as RLogical;
-    expect(await result.toLogical()).toEqual(true);
+    expect(await result.toBoolean()).toEqual(true);
     result = (await webR.evalR('FALSE')) as RLogical;
-    expect(await result.toLogical()).toEqual(false);
+    expect(await result.toBoolean()).toEqual(false);
     result = (await webR.evalR('NA')) as RLogical;
-    expect(await result.toLogical()).toEqual(null);
+    expect(await result.toBoolean()).toEqual(null);
   });
 
   test('Convert an R scalar raw to JS number', async () => {

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -321,7 +321,7 @@ describe('Working with R lists and vectors', () => {
     expect(await result.toBoolean()).toEqual(false);
     result = (await webR.evalR('NA')) as RLogical;
     expect(await result.toArray()).toEqual([null]);
-    await expect(result.toBoolean()).rejects.toThrow('Unable to convert missing value');
+    await expect(result.toBoolean()).rejects.toThrow("Can't convert missing value");
   });
 
   test('Convert an R scalar raw to JS number', async () => {

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -320,7 +320,8 @@ describe('Working with R lists and vectors', () => {
     result = (await webR.evalR('FALSE')) as RLogical;
     expect(await result.toBoolean()).toEqual(false);
     result = (await webR.evalR('NA')) as RLogical;
-    expect(await result.toBoolean()).toEqual(null);
+    expect(await result.toArray()).toEqual([null]);
+    await expect(result.toBoolean()).rejects.toThrow('Unable to convert missing value');
   });
 
   test('Convert an R scalar raw to JS number', async () => {

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -476,7 +476,7 @@ describe('Serialise nested R lists, pairlists and vectors unambiguously', () => 
     const env = await new webR.REnvironment({ newRObj, rObj });
     const identical = (await webR.evalR('identical(rObj, newRObj)', env)) as RLogical;
     expect(await rObj.type()).toEqual('list');
-    expect(await identical.toLogical()).toEqual(true);
+    expect(await identical.toBoolean()).toEqual(true);
   });
 
   test('Round trip convert to partial depth and ensure result is identical', async () => {
@@ -488,7 +488,7 @@ describe('Serialise nested R lists, pairlists and vectors unambiguously', () => 
     const env = await new webR.REnvironment({ newRObj, rObj });
     const identical = (await webR.evalR('identical(rObj, newRObj)', env)) as RLogical;
     expect(await rObj.type()).toEqual('list');
-    expect(await identical.toLogical()).toEqual(true);
+    expect(await identical.toBoolean()).toEqual(true);
   });
 });
 
@@ -500,17 +500,17 @@ describe('Access R objects via the main thread object cache', () => {
 
   test('R TRUE', async () => {
     expect(await webR.objs.true.type()).toEqual('logical');
-    expect(await webR.objs.true.toLogical()).toEqual(true);
+    expect(await webR.objs.true.toBoolean()).toEqual(true);
   });
 
   test('R FALSE', async () => {
     expect(await webR.objs.false.type()).toEqual('logical');
-    expect(await webR.objs.false.toLogical()).toEqual(false);
+    expect(await webR.objs.false.toBoolean()).toEqual(false);
   });
 
   test('Logical NA', async () => {
     expect(await webR.objs.na.type()).toEqual('logical');
-    expect(await webR.objs.na.toLogical()).toEqual(null);
+    expect(await webR.objs.na.toBoolean()).toEqual(null);
   });
 
   test('R global environment', async () => {

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -510,7 +510,7 @@ describe('Access R objects via the main thread object cache', () => {
 
   test('Logical NA', async () => {
     expect(await webR.objs.na.type()).toEqual('logical');
-    expect(await webR.objs.na.toBoolean()).toEqual(null);
+    expect(await webR.objs.na.toArray()).toEqual([null]);
   });
 
   test('R global environment', async () => {

--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -14,13 +14,13 @@ describe('Download and install binary webR packages', () => {
   test('Install packages via evalR', async () => {
     await webR.evalR('webr::install("cli", repos="https://repo.webr.workers.dev/")');
     const pkg = (await webR.evalR('"cli" %in% library(cli)')) as RLogical;
-    expect(await pkg.toLogical()).toEqual(true);
+    expect(await pkg.toBoolean()).toEqual(true);
   });
 
   test('Install packages via API', async () => {
     await webR.installPackages(['MASS']);
     const pkg = (await webR.evalR('"MASS" %in% library(MASS)')) as RLogical;
-    expect(await pkg.toLogical()).toEqual(true);
+    expect(await pkg.toBoolean()).toEqual(true);
   });
 });
 

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -237,7 +237,7 @@ export class ServiceWorkerChannelWorker implements ChannelWorker {
 
   constructor(data: { clientId?: string; location?: string }) {
     if (!data.clientId || !data.location) {
-      throw Error('Unable to start service worker channel');
+      throw Error("Can't start service worker channel");
     }
     this.#mainThreadId = data.clientId;
     this.#location = data.location;

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -84,7 +84,7 @@ export function newChannelMain(data: Required<WebROptions>) {
       if ('serviceWorker' in navigator && !isCrossOrigin(data.SW_URL)) {
         return new ServiceWorkerChannelMain(data);
       }
-      throw new Error('Unable to initialise main thread communication channel');
+      throw new Error("Can't initialise main thread communication channel");
   }
 }
 

--- a/src/webR/chan/serviceworker.ts
+++ b/src/webR/chan/serviceworker.ts
@@ -60,7 +60,7 @@ function handleMessage(event: ExtendableMessageEvent) {
       const source = event.source as WindowClient;
       self.clients.get(source.id).then((client) => {
         if (!client) {
-          throw new Error('Unable to respond to client in service worker message handler');
+          throw new Error("Can't respond to client in service worker message handler");
         }
         client.postMessage({
           type: 'registration-successful',

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -780,15 +780,15 @@ export class RLogical extends RVectorAtomic<boolean> {
     super({ payloadType: 'ptr', obj: { ptr } });
   }
 
-  getLogical(idx: number): boolean | null {
+  getBoolean(idx: number): boolean | null {
     return this.get(idx).toArray()[0];
   }
 
-  toLogical(): boolean | null {
+  toBoolean(): boolean | null {
     if (this.length !== 1) {
       throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
     }
-    return this.getLogical(1);
+    return this.getBoolean(1);
   }
 
   toTypedArray(): Int32Array {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -784,11 +784,15 @@ export class RLogical extends RVectorAtomic<boolean> {
     return this.get(idx).toArray()[0];
   }
 
-  toBoolean(): boolean | null {
+  toBoolean(): boolean {
     if (this.length !== 1) {
       throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
     }
-    return this.getBoolean(1);
+    const val = this.getBoolean(1);
+    if (val === null) {
+      throw new Error('Unable to convert missing value `NA` to a JS boolean');
+    }
+    return val;
   }
 
   toTypedArray(): Int32Array {
@@ -828,11 +832,15 @@ export class RInteger extends RVectorAtomic<number> {
     return this.get(idx).toArray()[0];
   }
 
-  toNumber(): number | null {
+  toNumber(): number {
     if (this.length !== 1) {
       throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
     }
-    return this.getNumber(1);
+    const val = this.getNumber(1);
+    if (val === null) {
+      throw new Error('Unable to convert missing value `NA` to a JS number');
+    }
+    return val;
   }
 
   toTypedArray(): Int32Array {
@@ -864,14 +872,18 @@ export class RDouble extends RVectorAtomic<number> {
   }
 
   getNumber(idx: number): number | null {
-    return this.get(idx).toTypedArray()[0];
+    return this.get(idx).toArray()[0];
   }
 
-  toNumber(): number | null {
+  toNumber(): number {
     if (this.length !== 1) {
       throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
     }
-    return this.getNumber(1);
+    const val = this.getNumber(1);
+    if (val === null) {
+      throw new Error('Unable to convert missing value `NA` to a JS number');
+    }
+    return val;
   }
 
   toTypedArray(): Float64Array {
@@ -906,11 +918,15 @@ export class RComplex extends RVectorAtomic<Complex> {
     return this.get(idx).toArray()[0];
   }
 
-  toComplex(): Complex | null {
+  toComplex(): Complex {
     if (this.length !== 1) {
       throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
     }
-    return this.getComplex(1);
+    const val = this.getComplex(1);
+    if (val === null) {
+      throw new Error('Unable to convert missing value `NA` to a JS object');
+    }
+    return val;
   }
 
   toTypedArray(): Float64Array {
@@ -957,11 +973,15 @@ export class RCharacter extends RVectorAtomic<string> {
     return this.get(idx).toArray()[0];
   }
 
-  toString(): string | null {
+  toString(): string {
     if (this.length !== 1) {
       throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
     }
-    return this.getString(1);
+    const val = this.getString(1);
+    if (val === null) {
+      throw new Error('Unable to convert missing value `NA` to a JS string');
+    }
+    return val;
   }
 
   toTypedArray(): Uint32Array {
@@ -1003,11 +1023,15 @@ export class RRaw extends RVectorAtomic<number> {
     return this.get(idx).toArray()[0];
   }
 
-  toNumber(): number | null {
+  toNumber(): number {
     if (this.length !== 1) {
       throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
     }
-    return this.getNumber(1);
+    const val = this.getNumber(1);
+    if (val === null) {
+      throw new Error('Unable to convert missing value `NA` to a JS number');
+    }
+    return val;
   }
 
   toTypedArray(): Uint8Array {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -611,7 +611,7 @@ export class REnvironment extends RObject {
     values.forEach((v, i) => {
       const name = names ? names[i] : null;
       if (!name) {
-        throw new Error('Unable to create object in new environment with empty symbol name');
+        throw new Error("Can't create object in new environment with empty symbol name");
       }
       const namePtr = Module.allocateUTF8(name);
       Module._Rf_defineVar(Module._Rf_install(namePtr), new RObject(v).ptr, ptr);
@@ -786,11 +786,11 @@ export class RLogical extends RVectorAtomic<boolean> {
 
   toBoolean(): boolean {
     if (this.length !== 1) {
-      throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
+      throw new Error("Can't convert atomic vector of length > 1 to a scalar JS value");
     }
     const val = this.getBoolean(1);
     if (val === null) {
-      throw new Error('Unable to convert missing value `NA` to a JS boolean');
+      throw new Error("Can't convert missing value `NA` to a JS boolean");
     }
     return val;
   }
@@ -834,11 +834,11 @@ export class RInteger extends RVectorAtomic<number> {
 
   toNumber(): number {
     if (this.length !== 1) {
-      throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
+      throw new Error("Can't convert atomic vector of length > 1 to a scalar JS value");
     }
     const val = this.getNumber(1);
     if (val === null) {
-      throw new Error('Unable to convert missing value `NA` to a JS number');
+      throw new Error("Can't convert missing value `NA` to a JS number");
     }
     return val;
   }
@@ -877,11 +877,11 @@ export class RDouble extends RVectorAtomic<number> {
 
   toNumber(): number {
     if (this.length !== 1) {
-      throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
+      throw new Error("Can't convert atomic vector of length > 1 to a scalar JS value");
     }
     const val = this.getNumber(1);
     if (val === null) {
-      throw new Error('Unable to convert missing value `NA` to a JS number');
+      throw new Error("Can't convert missing value `NA` to a JS number");
     }
     return val;
   }
@@ -920,11 +920,11 @@ export class RComplex extends RVectorAtomic<Complex> {
 
   toComplex(): Complex {
     if (this.length !== 1) {
-      throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
+      throw new Error("Can't convert atomic vector of length > 1 to a scalar JS value");
     }
     const val = this.getComplex(1);
     if (val === null) {
-      throw new Error('Unable to convert missing value `NA` to a JS object');
+      throw new Error("Can't convert missing value `NA` to a JS object");
     }
     return val;
   }
@@ -975,11 +975,11 @@ export class RCharacter extends RVectorAtomic<string> {
 
   toString(): string {
     if (this.length !== 1) {
-      throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
+      throw new Error("Can't convert atomic vector of length > 1 to a scalar JS value");
     }
     const val = this.getString(1);
     if (val === null) {
-      throw new Error('Unable to convert missing value `NA` to a JS string');
+      throw new Error("Can't convert missing value `NA` to a JS string");
     }
     return val;
   }
@@ -1025,11 +1025,11 @@ export class RRaw extends RVectorAtomic<number> {
 
   toNumber(): number {
     if (this.length !== 1) {
-      throw new Error('Unable to convert atomic vector of length > 1 to a scalar JS value');
+      throw new Error("Can't convert atomic vector of length > 1 to a scalar JS value");
     }
     const val = this.getNumber(1);
     if (val === null) {
-      throw new Error('Unable to convert missing value `NA` to a JS number');
+      throw new Error("Can't convert missing value `NA` to a JS number");
     }
     return val;
   }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -450,7 +450,7 @@ function init(config: Required<WebROptions>) {
 
     readConsole: () => {
       if (!chan) {
-        throw new Error('Unable to read console input without a communication channel');
+        throw new Error("Can't read console input without a communication channel");
       }
       return chan.inputOrDispatch();
     },


### PR DESCRIPTION
* Rename `toLogical` to `toBoolean`.
* Convert length 1 vectors to pure JS scalar types - e.g. `toBoolean()` returns `boolean` rather than `boolean | null`.

In the case of a length 1 atomic vector with a missing value of `NA`, an error is thrown.

For JS numbers, there is an alternative to throwing an error on `NA`: return `NaN` instead. This may be more natural as the JS `NaN` value counts as a pure `number` type, and since it is equal to the `NA` sentinel for doubles it has a simple implementation (simply return the first value from `toTypedArray()` rather than `toArray()`).

The downside is that everywhere else we use `null` rather than `NaN` to signal a missing value. In theory I think webR should treat them the same, but nevertheless I've kept things consistent for the moment and throw an error.