### PR TITLE
Add debugging tools to inspect addresses of R objects

### DIFF
--- a/packages/webr/R/utils.R
+++ b/packages/webr/R/utils.R
@@ -6,3 +6,7 @@ on_exit <- function(expr, env = parent.frame()) {
   )
   do.call("on.exit", args, envir = env)
 }
+
+obj_address <- function(x) {
+  .Call(ffi_obj_address, x)
+}

--- a/packages/webr/src/init.c
+++ b/packages/webr/src/init.c
@@ -1,12 +1,15 @@
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
-extern SEXP ffi_new_output_connections();
+
 extern SEXP ffi_eval_js(SEXP code);
+extern SEXP ffi_obj_address(SEXP x);
+extern SEXP ffi_new_output_connections();
 
 static
 const R_CallMethodDef CallEntries[] = {
-  { "ffi_new_output_connections", (DL_FUNC) &ffi_new_output_connections, 0},
   { "ffi_eval_js",                (DL_FUNC) &ffi_eval_js,                1},
+  { "ffi_obj_address",            (DL_FUNC) &ffi_obj_address,            1},
+  { "ffi_new_output_connections", (DL_FUNC) &ffi_new_output_connections, 0},
   { NULL,                         NULL,                                  0}
 };
 

--- a/packages/webr/src/utils.c
+++ b/packages/webr/src/utils.c
@@ -1,0 +1,17 @@
+#define R_NO_REMAP
+
+#include <R.h>
+#include <Rinternals.h>
+
+SEXP r_obj_address(SEXP x) {
+  static char buf[100];
+  snprintf(buf, 100, "%p", (void*) x);
+  return Rf_mkChar(buf);
+}
+
+SEXP ffi_obj_address(SEXP x) {
+  SEXP str = PROTECT(r_obj_address(x));
+  SEXP out = Rf_ScalarString(str);
+  UNPROTECT(1);
+  return out;
+}

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -1,7 +1,8 @@
-import { Module, DictEmPtrs, dictEmFree } from './emscripten';
+import { Module } from './emscripten';
 import { WebRPayload, isWebRPayload, isWebRPayloadPtr, isWebRPayloadRaw } from './payload';
 import { Complex, isComplex, NamedEntries, NamedObject, WebRDataRaw } from './robj';
 import { WebRData, WebRDataAtomic, RPtr, RType, RTypeMap, RTypeNumber } from './robj';
+import { parseEvalBare } from './utils-r';
 import { isWebRDataTree, WebRDataTree, WebRDataTreeAtomic, WebRDataTreeNode } from './tree';
 import { WebRDataTreeNull, WebRDataTreeString, WebRDataTreeSymbol } from './tree';
 
@@ -119,20 +120,7 @@ export class RObject {
   }
 
   inspect(): void {
-    const strings: DictEmPtrs = {};
-    let nProt = 0;
-
-    try {
-      const env = new REnvironment({ x: this });
-      env.protect();
-      ++nProt;
-
-      strings.code = Module.allocateUTF8('.Internal(inspect(x))');
-      Module._R_ParseEvalString(strings.code, env.ptr);
-    } finally {
-      dictEmFree(strings);
-      Module._Rf_unprotect(nProt);
-    }
+    parseEvalBare('.Internal(inspect(x))', { x: this });
   }
 
   isNull(): this is RNull {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -1,4 +1,4 @@
-import { Module } from './emscripten';
+import { Module, DictEmPtrs, dictEmFree } from './emscripten';
 import { WebRPayload, isWebRPayload, isWebRPayloadPtr, isWebRPayloadRaw } from './payload';
 import { Complex, isComplex, NamedEntries, NamedObject, WebRDataRaw } from './robj';
 import { WebRData, WebRDataAtomic, RPtr, RType, RTypeMap, RTypeNumber } from './robj';
@@ -116,6 +116,23 @@ export class RObject {
 
   release(): void {
     Module._R_ReleaseObject(this.ptr);
+  }
+
+  inspect(): void {
+    const strings: DictEmPtrs = {};
+    let nProt = 0;
+
+    try {
+      const env = new REnvironment({ x: this });
+      env.protect();
+      ++nProt;
+
+      strings.code = Module.allocateUTF8('.Internal(inspect(x))');
+      Module._R_ParseEvalString(strings.code, env.ptr);
+    } finally {
+      dictEmFree(strings);
+      Module._Rf_unprotect(nProt);
+    }
   }
 
   isNull(): this is RNull {

--- a/src/webR/utils-r.ts
+++ b/src/webR/utils-r.ts
@@ -1,0 +1,22 @@
+import { Module, DictEmPtrs, dictEmFree } from './emscripten';
+import { WebRData } from './robj';
+import { RObject, REnvironment } from './robj-worker';
+
+export function parseEvalBare(code: string, env: WebRData): RObject {
+  const strings: DictEmPtrs = {};
+  let nProt = 0;
+
+  try {
+    const envObj = new REnvironment(env);
+    envObj.protect();
+    ++nProt;
+
+    strings.code = Module.allocateUTF8(code);
+
+    const out = Module._R_ParseEvalString(strings.code, envObj.ptr);
+    return RObject.wrap(out);
+  } finally {
+    dictEmFree(strings);
+    Module._Rf_unprotect(nProt);
+  }
+}


### PR DESCRIPTION
For both the R and JS sides.

Also add `parseEvalBare()` helper to safely and easily evaluate R code with inputs. The `Bare` suffix anticipates the addition of a higher level `parseEval()` function that calls `evalR()`.