### PR TITLE
Always return `WebRPayload` when making a channel request

### DIFF
--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -4,6 +4,7 @@ import { ServiceWorkerChannelMain, ServiceWorkerChannelWorker } from './channel-
 import { WebROptions } from '../webr-main';
 import { isCrossOrigin } from '../utils';
 import { IN_NODE } from '../compat';
+import { WebRPayload } from '../payload';
 
 // The channel structure is asymetric:
 //
@@ -31,7 +32,7 @@ export interface ChannelMain {
   read(): Promise<Message>;
   flush(): Promise<Message[]>;
   write(msg: Message): void;
-  request(msg: Message, transferables?: [Transferable]): Promise<any>;
+  request(msg: Message, transferables?: [Transferable]): Promise<WebRPayload>;
   interrupt(): void;
 }
 

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -65,14 +65,14 @@ function empty() {}
 function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RWorker.RObject>) {
   return async function* () {
     // Get the R object's length
-    const reply = (await chan.request({
+    const reply = await chan.request({
       type: 'callRObjectMethod',
       data: {
         payload: proxy._payload,
         prop: 'getPropertyValue',
         args: [{ payloadType: 'raw', obj: 'length' }],
       },
-    })) as WebRPayload;
+    });
 
     // Throw an error if there was some problem accessing the object length
     if (reply.payloadType === 'err') {
@@ -111,10 +111,10 @@ export function targetMethod(chan: ChannelMain, prop: string, payload?: WebRPayl
       };
     });
 
-    const reply = (await chan.request({
+    const reply = await chan.request({
       type: 'callRObjectMethod',
       data: { payload, prop, args },
-    })) as WebRPayload;
+    });
 
     switch (reply.payloadType) {
       case 'ptr':
@@ -142,13 +142,13 @@ export function targetMethod(chan: ChannelMain, prop: string, payload?: WebRPayl
  * R object on the worker thread from a given JS object.
  */
 async function newRObject(chan: ChannelMain, objType: RType | 'object', value: unknown) {
-  const payload = (await chan.request({
+  const payload = await chan.request({
     type: 'newRObject',
     data: {
       objType,
       obj: replaceInObject(value, isRObject, (obj: RObject) => obj._payload),
     },
-  })) as WebRPayload;
+  });
   switch (payload.payloadType) {
     case 'raw':
       throw new Error('Unexpected raw payload type returned from newRObject');

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -2,7 +2,6 @@ import { newChannelMain, ChannelMain, ChannelType } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { newRProxy, newRClassProxy } from './proxy';
-import { WebRPayload } from './payload';
 import { isRObject, RCharacter, RComplex, RDouble, REnvironment, RInteger } from './robj-main';
 import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString } from './robj-main';
 import * as RWorker from './robj-worker';
@@ -137,10 +136,11 @@ export class WebR {
     return await this.#chan.request(msg);
   }
   async getFileData(name: string): Promise<Uint8Array> {
-    return (await this.#chan.request({ type: 'getFileData', data: { name: name } })) as Uint8Array;
+    return (await this.#chan.request({ type: 'getFileData', data: { name: name } }))
+      .obj as Uint8Array;
   }
   async getFSNode(path: string): Promise<FSNode> {
-    return (await this.#chan.request({ type: 'getFSNode', data: { path: path } })) as FSNode;
+    return (await this.#chan.request({ type: 'getFSNode', data: { path: path } })).obj as FSNode;
   }
 
   async captureR(
@@ -155,14 +155,14 @@ export class WebR {
       throw new Error('Attempted to evaluate R code with invalid environment object');
     }
 
-    const payload = (await this.#chan.request({
+    const payload = await this.#chan.request({
       type: 'captureR',
       data: {
         code: code,
         env: env?._payload,
         options: options,
       },
-    })) as WebRPayload;
+    });
 
     switch (payload.payloadType) {
       case 'raw':
@@ -199,10 +199,10 @@ export class WebR {
       throw new Error('Attempted to evaluate R code with invalid environment object');
     }
 
-    const payload = (await this.#chan.request({
+    const payload = await this.#chan.request({
       type: 'evalR',
       data: { code: code, env: env?._payload },
-    })) as WebRPayload;
+    });
 
     switch (payload.payloadType) {
       case 'raw':


### PR DESCRIPTION
With this commit, `ChannelMain.request` is modified to always return a `WebRPayload`. This formalises what we were pretty much doing anyway.

With this change, we also move the `try`-`catch` blocks that capture errors thrown on the worker thread higher up the stack, wrapping the entire branch of `dispatch()` that deals with requests.

The change provides three immediate benefits,
 * Avoids multiple type casting to `WebRPayload` throughout,
 * Avoids repeated code,
 * Any errors that occur during a webR request are captured and handled, rather than in just some branches and not others.

This fixes an issue where some webR errors during a request (in particular, FS errors) break the worker's main R loop. By always capturing the errors and sending them to the main thread to be dealt with, the  main R loop continues and webR can recover gracefully.

With this PR FS errors are not properly handled on the main thread, but the FS code is being refactored in a future linked PR in any case.