### PR TITLE
Expand and reorganise webR virtual filesystem API

### DIFF
--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -53,7 +53,7 @@ function FSTreeData(
   }
 ) {
   if (obj.id === '#') {
-    webR.getFSNode('/').then((node: FSNode) => {
+    webR.FS.lookupPath('/').then((node: FSNode) => {
       const jsTreeNode = FSTree.createJSTreeNodefromFSNode(node);
       jsTreeNode.parents = [];
       cb.call(FSTree, jsTreeNode);
@@ -101,7 +101,7 @@ const webR = new WebR({
       if (!node) return;
 
       const filepath = FSTree.getNodeFileName(node);
-      webR.getFileData(filepath).then((data) => {
+      webR.FS.readFile(filepath).then((data) => {
         const filename = node.text;
         const blob = new Blob([data], { type: 'application/octet-stream' });
         const url = URL.createObjectURL(blob);
@@ -136,7 +136,7 @@ const webR = new WebR({
           fr.onload = async function () {
             upload.value = '';
             const data = new Uint8Array(fr.result as ArrayBuffer);
-            await webR.putFileData(filepath + '/' + file.name, data);
+            await webR.FS.writeFile(filepath + '/' + file.name, data);
             FSTree.refresh();
           };
 

--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -43,10 +43,29 @@ describe('Test webR virtual filesystem', () => {
     expect(fileInfo).toHaveProperty('isFolder', false);
   });
 
+  test('Delete a file on the VFS', async () => {
+    await expect(webR.FS.unlink('/tmp/testFile')).resolves.not.toThrow();
+    const dirInfo = await webR.FS.lookupPath('/tmp');
+    expect(Object.keys(dirInfo.contents)).not.toContain('testFile');
+  });
+
+  test('Create a new directory on the VFS', async () => {
+    await expect(webR.FS.mkdir('/newdir')).resolves.not.toThrow();
+    const dirInfo = webR.FS.lookupPath('/newdir');
+    expect(await dirInfo).toHaveProperty('name', 'newdir');
+    expect(await dirInfo).toHaveProperty('isFolder', true);
+  });
+
   test('Receive information about a directory on the VFS', async () => {
-    const fileInfo = await webR.FS.lookupPath('/tmp');
-    expect(fileInfo).toHaveProperty('name', 'tmp');
+    const fileInfo = await webR.FS.lookupPath('/newdir');
+    expect(fileInfo).toHaveProperty('name', 'newdir');
     expect(fileInfo).toHaveProperty('isFolder', true);
+  });
+
+  test('Remove a directory on the VFS', async () => {
+    await expect(webR.FS.rmdir('/newdir')).resolves.not.toThrow();
+    const dirInfo = await webR.FS.lookupPath('/');
+    expect(Object.keys(dirInfo.contents)).not.toContain('newdir');
   });
 });
 

--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -27,24 +27,24 @@ describe('Download and install binary webR packages', () => {
 describe('Test webR virtual filesystem', () => {
   const testFileContents = new Uint8Array([1, 2, 4, 7, 11, 16, 22, 29, 37, 46]);
   test('Upload a file to the VFS', async () => {
-    await expect(webR.putFileData('/tmp/testFile', testFileContents)).resolves.not.toThrow();
+    await expect(webR.FS.writeFile('/tmp/testFile', testFileContents)).resolves.not.toThrow();
     const readFile = (await webR.evalR('readBin("/tmp/testFile", "raw", 10)')) as RRaw;
     expect(Array.from(await readFile.toArray())).toEqual(Array.from(testFileContents));
   });
 
   test('Download a file from the VFS', async () => {
-    const fileContents = await webR.getFileData('/tmp/testFile');
+    const fileContents = await webR.FS.readFile('/tmp/testFile');
     expect(fileContents).toStrictEqual(testFileContents);
   });
 
   test('Receive information about a file on the VFS', async () => {
-    const fileInfo = await webR.getFSNode('/tmp/testFile');
+    const fileInfo = await webR.FS.lookupPath('/tmp/testFile');
     expect(fileInfo).toHaveProperty('name', 'testFile');
     expect(fileInfo).toHaveProperty('isFolder', false);
   });
 
   test('Receive information about a directory on the VFS', async () => {
-    const fileInfo = await webR.getFSNode('/tmp');
+    const fileInfo = await webR.FS.lookupPath('/tmp');
     expect(fileInfo).toHaveProperty('name', 'tmp');
     expect(fileInfo).toHaveProperty('isFolder', true);
   });

--- a/src/webR/payload.ts
+++ b/src/webR/payload.ts
@@ -24,6 +24,13 @@ export type WebRPayloadErr = {
 };
 export type WebRPayload = WebRPayloadRaw | WebRPayloadPtr | WebRPayloadErr;
 
+export function webRPayloadError(payload: WebRPayloadErr): Error {
+  const e = new Error(payload.obj.message);
+  e.name = payload.obj.name;
+  e.stack = payload.obj.stack;
+  return e;
+}
+
 /**
  * Test for an WebRPayload instance.
  *

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -131,17 +131,6 @@ export class WebR {
       await this.#chan.request(msg);
     }
   }
-  async putFileData(name: string, data: Uint8Array) {
-    const msg = { type: 'putFileData', data: { name: name, data: data } };
-    return await this.#chan.request(msg);
-  }
-  async getFileData(name: string): Promise<Uint8Array> {
-    return (await this.#chan.request({ type: 'getFileData', data: { name: name } }))
-      .obj as Uint8Array;
-  }
-  async getFSNode(path: string): Promise<FSNode> {
-    return (await this.#chan.request({ type: 'getFSNode', data: { path: path } })).obj as FSNode;
-  }
 
   async captureR(
     code: string,
@@ -218,4 +207,26 @@ export class WebR {
       }
     }
   }
+
+  FS = {
+    lookupPath: async (path: string): Promise<FSNode> => {
+      return (await this.#chan.request({ type: 'lookupPath', data: { path } })).obj as FSNode;
+    },
+    mkdir: async (path: string): Promise<FSNode> => {
+      return (await this.#chan.request({ type: 'mkdir', data: { path } })).obj as FSNode;
+    },
+    readFile: async (path: string, flags?: string): Promise<Uint8Array> => {
+      return (await this.#chan.request({ type: 'readFile', data: { path, flags } }))
+        .obj as Uint8Array;
+    },
+    rmdir: async (path: string): Promise<void> => {
+      await this.#chan.request({ type: 'rmdir', data: { path } });
+    },
+    writeFile: async (path: string, data: ArrayBufferView, flags?: string): Promise<void> => {
+      await this.#chan.request({ type: 'writeFile', data: { path, data, flags } });
+    },
+    unlink: async (path: string): Promise<void> => {
+      await this.#chan.request({ type: 'unlink', data: { path } });
+    },
+  };
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -210,23 +210,61 @@ export class WebR {
 
   FS = {
     lookupPath: async (path: string): Promise<FSNode> => {
-      return (await this.#chan.request({ type: 'lookupPath', data: { path } })).obj as FSNode;
+      const payload = await this.#chan.request({ type: 'lookupPath', data: { path } });
+      if (payload.payloadType === 'err') {
+        const e = new Error(payload.obj.message);
+        e.name = payload.obj.name;
+        e.stack = payload.obj.stack;
+        throw e;
+      }
+      return payload.obj as FSNode;
     },
     mkdir: async (path: string): Promise<FSNode> => {
-      return (await this.#chan.request({ type: 'mkdir', data: { path } })).obj as FSNode;
+      const payload = await this.#chan.request({ type: 'mkdir', data: { path } });
+      if (payload.payloadType === 'err') {
+        const e = new Error(payload.obj.message);
+        e.name = payload.obj.name;
+        e.stack = payload.obj.stack;
+        throw e;
+      }
+      return payload.obj as FSNode;
     },
     readFile: async (path: string, flags?: string): Promise<Uint8Array> => {
-      return (await this.#chan.request({ type: 'readFile', data: { path, flags } }))
-        .obj as Uint8Array;
+      const payload = await this.#chan.request({ type: 'readFile', data: { path, flags } });
+      if (payload.payloadType === 'err') {
+        const e = new Error(payload.obj.message);
+        e.name = payload.obj.name;
+        e.stack = payload.obj.stack;
+        throw e;
+      }
+      return payload.obj as Uint8Array;
     },
     rmdir: async (path: string): Promise<void> => {
-      await this.#chan.request({ type: 'rmdir', data: { path } });
+      const payload = await this.#chan.request({ type: 'rmdir', data: { path } });
+      if (payload.payloadType === 'err') {
+        const e = new Error(payload.obj.message);
+        e.name = payload.obj.name;
+        e.stack = payload.obj.stack;
+        throw e;
+      }
     },
     writeFile: async (path: string, data: ArrayBufferView, flags?: string): Promise<void> => {
-      await this.#chan.request({ type: 'writeFile', data: { path, data, flags } });
+      const payload = await this.#chan.request({ type: 'writeFile', data: { path, data, flags } });
+      if (payload.payloadType === 'err') {
+        const e = new Error(payload.obj.message);
+        e.name = payload.obj.name;
+        e.stack = payload.obj.stack;
+        throw e;
+      }
     },
     unlink: async (path: string): Promise<void> => {
-      await this.#chan.request({ type: 'unlink', data: { path } });
+      const payload = await this.#chan.request({ type: 'unlink', data: { path } });
+      if (payload.payloadType === 'err') {
+        const e = new Error(payload.obj.message);
+        e.name = payload.obj.name;
+        e.stack = payload.obj.stack;
+        throw e;
+      }
     },
   };
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -1,6 +1,7 @@
 import { newChannelMain, ChannelMain, ChannelType } from './chan/channel';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
+import { webRPayloadError } from './payload';
 import { newRProxy, newRClassProxy } from './proxy';
 import { isRObject, RCharacter, RComplex, RDouble, REnvironment, RInteger } from './robj-main';
 import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString } from './robj-main';
@@ -156,12 +157,8 @@ export class WebR {
     switch (payload.payloadType) {
       case 'raw':
         throw new Error('Unexpected raw payload type returned from evalR');
-      case 'err': {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
-      }
+      case 'err':
+        throw webRPayloadError(payload);
       default: {
         const obj = newRProxy(this.#chan, payload);
         obj.preserve();
@@ -196,15 +193,10 @@ export class WebR {
     switch (payload.payloadType) {
       case 'raw':
         throw new Error('Unexpected raw payload type returned from evalR');
-      case 'err': {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
-      }
-      default: {
+      case 'err':
+        throw webRPayloadError(payload);
+      default:
         return newRProxy(this.#chan, payload);
-      }
     }
   }
 
@@ -212,58 +204,40 @@ export class WebR {
     lookupPath: async (path: string): Promise<FSNode> => {
       const payload = await this.#chan.request({ type: 'lookupPath', data: { path } });
       if (payload.payloadType === 'err') {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
+        throw webRPayloadError(payload);
       }
       return payload.obj as FSNode;
     },
     mkdir: async (path: string): Promise<FSNode> => {
       const payload = await this.#chan.request({ type: 'mkdir', data: { path } });
       if (payload.payloadType === 'err') {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
+        throw webRPayloadError(payload);
       }
       return payload.obj as FSNode;
     },
     readFile: async (path: string, flags?: string): Promise<Uint8Array> => {
       const payload = await this.#chan.request({ type: 'readFile', data: { path, flags } });
       if (payload.payloadType === 'err') {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
+        throw webRPayloadError(payload);
       }
       return payload.obj as Uint8Array;
     },
     rmdir: async (path: string): Promise<void> => {
       const payload = await this.#chan.request({ type: 'rmdir', data: { path } });
       if (payload.payloadType === 'err') {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
+        throw webRPayloadError(payload);
       }
     },
     writeFile: async (path: string, data: ArrayBufferView, flags?: string): Promise<void> => {
       const payload = await this.#chan.request({ type: 'writeFile', data: { path, data, flags } });
       if (payload.payloadType === 'err') {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
+        throw webRPayloadError(payload);
       }
     },
     unlink: async (path: string): Promise<void> => {
       const payload = await this.#chan.request({ type: 'unlink', data: { path } });
       if (payload.payloadType === 'err') {
-        const e = new Error(payload.obj.message);
-        e.name = payload.obj.name;
-        e.stack = payload.obj.stack;
-        throw e;
+        throw webRPayloadError(payload);
       }
     },
   };


### PR DESCRIPTION
Requires #126.

Expands and reorganises the webR filesystem API,
 * Move functions into a `FS` namespace.
 * Add new `mkdir`, `rmdir`, and `unlink` functions.
 * Rename existing functions to match Emscripten FS API.
 * Re-throw any error payloads returned.