### PR TITLE
Update env methods

### DIFF
--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -464,6 +464,12 @@ describe('Create R objects from JS objects using proxy constructors', () => {
     expect(await elem.type()).toEqual('double');
     expect(await elem.toNumber()).toEqual(456);
   });
+
+  test('Create a symbol', async () => {
+    const rObj = await new webR.RSymbol('foo');
+    expect(await rObj.type()).toEqual('symbol');
+    expect(await rObj.toString()).toEqual('foo');
+  });
 });
 
 describe('Serialise nested R lists, pairlists and vectors unambiguously', () => {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -6,6 +6,16 @@ import { parseEvalBare } from './utils-r';
 import { isWebRDataTree, WebRDataTree, WebRDataTreeAtomic, WebRDataTreeNode } from './tree';
 import { WebRDataTreeNull, WebRDataTreeString, WebRDataTreeSymbol } from './tree';
 
+export type RHandle = RObject | RPtr;
+
+export function handlePtr(x: RHandle): RPtr {
+  if (isRObject(x)) {
+    return x.ptr;
+  } else {
+    return x;
+  }
+}
+
 export interface ToTreeOptions {
   depth: number;
 }

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -375,6 +375,24 @@ export class RNull extends RObject {
 }
 
 export class RSymbol extends RObject {
+  // Note that symbols don't need to be protected. This also means
+  // that allocating symbols in loops with random data is probably a
+  // bad idea because this leaks memory.
+  constructor(x: string) {
+    if (typeof x !== 'string') {
+      super(x);
+      return;
+    }
+
+    const name = Module.allocateUTF8(x);
+
+    try {
+      super(RObject.wrap(Module._Rf_install(name)));
+    } finally {
+      Module._free(name);
+    }
+  }
+
   toTree(): WebRDataTreeSymbol {
     const obj = this.toObject();
     return {
@@ -395,6 +413,10 @@ export class RSymbol extends RObject {
       symvalue: this.symvalue().isUnbound() ? null : this.symvalue().ptr,
       internal: this.internal().isNull() ? null : this.internal().ptr,
     };
+  }
+
+  toString(): string {
+    return this.printname().toString();
   }
 
   printname(): RString {

--- a/src/webR/utils-r.ts
+++ b/src/webR/utils-r.ts
@@ -1,18 +1,20 @@
 import { Module, DictEmPtrs, dictEmFree } from './emscripten';
-import { RPtr, WebRData } from './robj';
-import { RObject, isRObject, REnvironment } from './robj-worker';
+import { WebRData } from './robj';
+import { RObject, REnvironment, RHandle, handlePtr } from './robj-worker';
 
-export function protect<T extends RObject | RPtr>(x: T): T {
-  if (isRObject(x)) {
-    Module._Rf_protect(x.ptr);
-  } else {
-    Module._Rf_protect(x);
-  }
+export function protect<T extends RHandle>(x: T): T {
+  Module._Rf_protect(handlePtr(x));
   return x;
 }
 
 export function unprotect(n: number) {
   Module._Rf_unprotect(n);
+}
+
+// rlang convention: `env`-prefixed functions consistently take `env`
+// as first argument
+export function envPoke(env: RHandle, sym: RHandle, value: RHandle) {
+  Module._Rf_defineVar(handlePtr(sym), handlePtr(value), handlePtr(env));
 }
 
 export function parseEvalBare(code: string, env: WebRData): RObject {

--- a/src/webR/utils-r.ts
+++ b/src/webR/utils-r.ts
@@ -1,6 +1,19 @@
 import { Module, DictEmPtrs, dictEmFree } from './emscripten';
-import { WebRData } from './robj';
-import { RObject, REnvironment } from './robj-worker';
+import { RPtr, WebRData } from './robj';
+import { RObject, isRObject, REnvironment } from './robj-worker';
+
+export function protect<T extends RObject | RPtr>(x: T): T {
+  if (isRObject(x)) {
+    Module._Rf_protect(x.ptr);
+  } else {
+    Module._Rf_protect(x);
+  }
+  return x;
+}
+
+export function unprotect(n: number) {
+  Module._Rf_unprotect(n);
+}
 
 export function parseEvalBare(code: string, env: WebRData): RObject {
   const strings: DictEmPtrs = {};

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -3,7 +3,8 @@ import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { webRPayloadError } from './payload';
 import { newRProxy, newRClassProxy } from './proxy';
-import { isRObject, RCharacter, RComplex, RDouble, REnvironment, RInteger } from './robj-main';
+import { isRObject, RCharacter, RComplex, RDouble } from './robj-main';
+import { REnvironment, RSymbol, RInteger } from './robj-main';
 import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString } from './robj-main';
 import * as RWorker from './robj-worker';
 
@@ -64,6 +65,7 @@ export class WebR {
   RList;
   RPairlist;
   REnvironment;
+  RSymbol;
   objs: {
     baseEnv: REnvironment;
     globalEnv: REnvironment;
@@ -87,6 +89,7 @@ export class WebR {
     this.RList = newRClassProxy<typeof RWorker.RList, RList>(c, 'list');
     this.RPairlist = newRClassProxy<typeof RWorker.RPairlist, RPairlist>(c, 'pairlist');
     this.REnvironment = newRClassProxy<typeof RWorker.REnvironment, REnvironment>(c, 'environment');
+    this.RSymbol = newRClassProxy<typeof RWorker.RSymbol, RSymbol>(c, 'symbol');
     this.objs = {} as typeof this.objs;
   }
 


### PR DESCRIPTION
This PR updates the `new()` and `bind()` methods of `REnvironment` to fix memory leaks. It takes this opportunity to introduce and use wrappers of the `Module` entry points.

- Add the foundation for memory management on the worker side: `keep()` for implicit protection of objects sent to the main thread, `RObject.free()` for release on the main side, `protect()` and `unprotect()` wrappers for temporary protection on the worker side.

- `protect()` is generic and takes `RHandle = RObject | RPtr`. A new `handlePtr()` function helps extracting a pointer.

- Add `envPoke()` wrapper that takes `RHandle` inputs.

- Update the `new()` and `bind()` methods of `REnvironment` to use the above and fix potential leaks in the process.

- Add `string` constructor for symbols. Used to create symbols without having to manage the C string memory.

I plan to go over the rest of the file in a new PR.