### PR TITLE
Consistently preserve objects before transmission

### DIFF
--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -26,7 +26,8 @@ function resizeTerm() {
   (async () => {
     await webR.init();
     const dims = fitAddon.proposeDimensions();
-    webR.evalR(`options(width=${dims ? dims.cols : 80})`);
+    // TODO: Replace by void version of `evalR()`
+    (await webR.evalR(`options(width=${dims ? dims.cols : 80})`)).destroy();
   })();
   fitAddon.fit();
 }
@@ -77,7 +78,11 @@ const webR = new WebR({
 
   readline.setCtrlCHandler(() => webR.interrupt());
 
-  webR.captureR('webr::global_prompt_install()', undefined, { withHandlers: false });
+  // TODO: Replace by void version of `evalR()`
+  const out = await webR.captureR('webr::global_prompt_install()', undefined, {
+    withHandlers: false,
+  });
+  out.result.destroy();
 
   // Clear the loading message
   term.write('\x1b[2K\r');

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -518,28 +518,21 @@ describe('Reject incorrect object types during R object construction', () => {
 });
 
 describe('Garbage collection', () => {
-  test.skip('Protect and release R objects', async () => {
+  test('Protect and release R objects', async () => {
     const gc = (await webR.evalR('gc')) as RFunction;
     await gc.exec(false, false, true);
     const before = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 
     const mem = await webR.evalR('rnorm(10000,1,1)');
-    mem.destroy();
-
     const during = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 
+    mem.destroy();
     const after = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 
     expect(during[0]).toBeGreaterThan(before[0]);
     expect(during[1]).toBeGreaterThan(before[1]);
 
-    // TODO: For some reason `exec()` causes this test to fail after
-    // switching to protect(). Also we now temporarily call `keep()`
-    // from `new RObject()` so there's bound to be leaks until this is
-    // moved to the channel (for instance this causes new symbols to
-    // be preserved).
     expect(after[0]).toBeLessThan(during[0]);
-
     expect(after[1]).toBeLessThan(during[1]);
   });
 });

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -524,10 +524,10 @@ describe('Garbage collection', () => {
     const before = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 
     const mem = await webR.evalR('rnorm(10000,1,1)');
-    mem.preserve();
+    mem.destroy();
+
     const during = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 
-    mem.release();
     const after = await ((await gc.exec(false, false, true)) as RDouble).toTypedArray();
 
     expect(during[0]).toBeGreaterThan(before[0]);

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -138,23 +138,7 @@ export class RObject extends RObjectBase {
   // Frees objects preserved with `keep()`. This method is called by
   // users in the main thread to release objects that were
   // automatically protected before being sent away.
-  free(): void {
-    Module._R_ReleaseObject(this.ptr);
-  }
-
-  // TODO: Remove these
-  protect(): void {
-    this.ptr = Module._Rf_protect(this.ptr);
-  }
-  unprotect(): void {
-    Module._Rf_unprotect_ptr(this.ptr);
-  }
-
-  // TODO: Remove these
-  preserve(): void {
-    Module._R_PreserveObject(this.ptr);
-  }
-  release(): void {
+  destroy(): void {
     Module._R_ReleaseObject(this.ptr);
   }
 
@@ -353,26 +337,6 @@ export class RObject extends RObjectBase {
 
   static get namesSymbol(): RSymbol {
     return RSymbol.wrap(Module.getValue(Module._R_NamesSymbol, '*'));
-  }
-
-  static protect<T extends RObject>(obj: T): T {
-    return RObject.wrap(Module._Rf_protect(obj.ptr)) as T;
-  }
-
-  static unprotect(n: number): void {
-    Module._Rf_unprotect(n);
-  }
-
-  static unprotectPtr(obj: RObject): void {
-    Module._Rf_unprotect_ptr(obj.ptr);
-  }
-
-  static preserveObject(obj: RObject): void {
-    Module._R_PreserveObject(obj.ptr);
-  }
-
-  static releaseObject(obj: RObject): void {
-    Module._R_ReleaseObject(obj.ptr);
   }
 }
 

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -27,7 +27,7 @@ function assertRType(obj: RObjectBase, type: RType) {
 // thread. Currently uses the precious list but could use a different
 // mechanism in the future. Unprotection is explicit through
 // `RObject.free()`.
-function keep(x: RHandle) {
+export function keep(x: RHandle) {
   Module._R_PreserveObject(handlePtr(x));
 }
 

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -102,20 +102,11 @@ export class RObjectBase {
 
 export class RObject extends RObjectBase {
   constructor(data: WebRData) {
-    super(0);
-    try {
-      if (data instanceof RObjectBase) {
-        this.ptr = data.ptr;
-        return this;
-      }
+    if (!(data instanceof RObjectBase)) {
       return newObjectFromData(data);
-    } finally {
-      // FIXME: Shouldn't preserve in the constructor, only in channel
-      // messages
-      if (this.ptr) {
-        keep(this.ptr);
-      }
     }
+
+    super(data.ptr);
   }
 
   static wrap<T extends typeof RObject>(this: T, ptr: RPtr): InstanceType<T> {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -26,7 +26,7 @@ function assertRType(obj: RObjectBase, type: RType) {
 // Use this for implicit protection of objects sent to the main
 // thread. Currently uses the precious list but could use a different
 // mechanism in the future. Unprotection is explicit through
-// `RObject.free()`.
+// `RObject.destroy()`.
 export function keep(x: RHandle) {
   Module._R_PreserveObject(handlePtr(x));
 }

--- a/src/webR/utils-r.ts
+++ b/src/webR/utils-r.ts
@@ -46,12 +46,11 @@ export function envPoke(env: RHandle, sym: RHandle, value: RHandle) {
 
 export function parseEvalBare(code: string, env: WebRData): RObject {
   const strings: DictEmPtrs = {};
-  let nProt = 0;
+  const prot = { n: 0 };
 
   try {
     const envObj = new REnvironment(env);
-    envObj.protect();
-    ++nProt;
+    protectInc(envObj, prot);
 
     strings.code = Module.allocateUTF8(code);
 
@@ -59,6 +58,6 @@ export function parseEvalBare(code: string, env: WebRData): RObject {
     return RObject.wrap(out);
   } finally {
     dictEmFree(strings);
-    Module._Rf_unprotect(nProt);
+    unprotect(prot.n);
   }
 }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -170,12 +170,6 @@ function dispatch(msg: Message): void {
                   output: output,
                 },
               });
-            } catch (_e) {
-              const e = _e as Error;
-              write({
-                payloadType: 'err',
-                obj: { name: e.name, message: e.message, stack: e.stack },
-              });
             } finally {
               unprotect(prot.n);
             }


### PR DESCRIPTION
Branched from #134.
Part of #128.

- Move implicit protection from the `RObject` ctor to the channel dispatcher.

- The `captureR()` unwrapping of stdout/stderr outputs now happens on the worker side. This spares channel transmissions.

- Add `destroy()` method to `RObject` and remove other memory methods. I've called it `destroy()` because we are planning to disable objects that have been released, and this name makes it clear that the object can no longer be used after this method has been called.