### PR TITLE
Simply R object construction using new `RObjectBase` class for R object references

### DIFF
--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -68,6 +68,7 @@ export type NamedObject<T> = { [key: string]: T };
  */
 export type WebRData =
   | RMain.RObject
+  | RWorker.RObjectBase
   | RWorker.RObject
   | WebRDataRaw
   | WebRDataTree

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -323,10 +323,8 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
     const tPtr = RObject.true.ptr;
     const fPtr = RObject.false.ptr;
 
-    strings.code = Module.allocateUTF8(code);
     strings.eval = Module.allocateUTF8('webr::eval_r');
-
-    const codeObj = new RObject({ payloadType: 'raw', obj: code });
+    const codeObj = new RObject(code);
     Module._Rf_protect(codeObj.ptr);
     ++nProt;
 


### PR DESCRIPTION
Simplify the construction of `RObject` and its subclasses so as to not need to work with `WebRPayload` objects. This feels better since we're not working with transferring data over the channel here.

We need to discriminate between `WebRData` and `RPtr` during `RObject` construction, since we can't always use `wrap()` inside subclass constructors as it leads to an infloop.

A new `RObjectBase` class is added that just sets `obj.ptr` and does nothing else. Instances of `RObjectBase` are constructed and used to signal to the `RObject` constructors that we have an existing `RPtr`. During object construction what was `{ payloadType: 'ptr', obj: { ptr } }` now becomes `new RObjectBase(ptr)`, and `{ payloadType: 'raw', obj: foo }` just becomes `foo`.

`RObjectBase` is set as a super class to `RObject`. This helps when testing for "`RObject` or `RObjectBase`", in that with this hierarchy in place both can be tested for at once with `obj instanceof RObjectBase`. It also fits well in that an R object reference fundamentally is just a Wasm pointer.

The `isRObject()` implementation has also been simplified.

