### PR TITLE
Check object type in `RObject` subclass constructors and reject incorrect objects

### DIFF
--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -460,6 +460,63 @@ describe('Invoking RFunction objects', () => {
   });
 });
 
+describe('Reject incorrect object types during R object construction', () => {
+  test('Reject incorrect type in RCharacter', async () => {
+    const incorrect = new webR.RCharacter(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RComplex', async () => {
+    const incorrect = new webR.RComplex(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RDouble', async () => {
+    const incorrect = new webR.RDouble(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in REnvironment', async () => {
+    const incorrect = new webR.REnvironment(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RInteger', async () => {
+    const incorrect = new webR.RInteger(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RList', async () => {
+    const incorrect = new webR.RList(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RLogical', async () => {
+    const incorrect = new webR.RLogical(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RPairlist', async () => {
+    const incorrect = new webR.RPairlist(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RRaw', async () => {
+    const incorrect = new webR.RRaw(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RString', async () => {
+    const incorrect = new webR.RString(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+
+  test('Reject incorrect type in RSymbol', async () => {
+    const incorrect = new webR.RSymbol(webR.objs.null);
+    await expect(incorrect).rejects.toThrow('Unexpected object type');
+  });
+});
+
 describe('Garbage collection', () => {
   test.skip('Protect and release R objects', async () => {
     const gc = (await webR.evalR('gc')) as RFunction;

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -470,6 +470,12 @@ describe('Create R objects from JS objects using proxy constructors', () => {
     expect(await rObj.type()).toEqual('symbol');
     expect(await rObj.toString()).toEqual('foo');
   });
+
+  test('Create a string', async () => {
+    const rObj = await new webR.RString('foo');
+    expect(await rObj.type()).toEqual('string');
+    expect(await rObj.toString()).toEqual('foo');
+  });
 });
 
 describe('Serialise nested R lists, pairlists and vectors unambiguously', () => {

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -476,6 +476,20 @@ describe('Create R objects from JS objects using proxy constructors', () => {
     expect(await rObj.type()).toEqual('string');
     expect(await rObj.toString()).toEqual('foo');
   });
+
+  test('Create a call', async () => {
+    const c = await new webR.RSymbol('c');
+    const rObj = await new webR.RCall([c, 1, 2, 3, 'x', 'y', 'z']);
+    const res = await rObj.exec();
+    expect(await rObj.type()).toEqual('call');
+    expect(await res.type()).toEqual('character');
+    expect(await res.toJs()).toEqual(
+      expect.objectContaining({
+        values: ['1', '2', '3', 'x', 'y', 'z'],
+        names: null,
+      })
+    );
+  });
 });
 
 describe('Serialise nested R lists, pairlists and vectors unambiguously', () => {

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -480,7 +480,7 @@ describe('Create R objects from JS objects using proxy constructors', () => {
   test('Create a call', async () => {
     const c = await new webR.RSymbol('c');
     const rObj = await new webR.RCall([c, 1, 2, 3, 'x', 'y', 'z']);
-    const res = await rObj.exec();
+    const res = await rObj.eval();
     expect(await rObj.type()).toEqual('call');
     expect(await res.type()).toEqual('character');
     expect(await res.toJs()).toEqual(

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -185,7 +185,7 @@ export function newRClassProxy<T, R>(chan: ChannelMain, objType: RType | 'object
     ? {
         new (
           ...args: {
-            [V in keyof U]: Exclude<U[V], WebRPayload>;
+            [V in keyof U]: U[V];
           }
         ): Promise<R>;
       }

--- a/src/webR/robj-main.ts
+++ b/src/webR/robj-main.ts
@@ -16,6 +16,7 @@ export type RComplex = RProxy<RWorker.RComplex>;
 export type RCharacter = RProxy<RWorker.RCharacter>;
 export type RList = RProxy<RWorker.RList>;
 export type RRaw = RProxy<RWorker.RRaw>;
+export type RCall = RProxy<RWorker.RCall>;
 // RFunction proxies are callable
 export type RFunction = RProxy<RWorker.RFunction> & ((...args: unknown[]) => Promise<unknown>);
 

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -399,6 +399,9 @@ export class RSymbol extends RObject {
   // bad idea because this leaks memory.
   constructor(x: WebRDataScalar<string>) {
     if (x instanceof RObjectBase) {
+      if (Module._TYPEOF(x.ptr) !== RTypeMap.symbol) {
+        throw new Error('Unexpected object type in `RSymbol` constructor');
+      }
       super(x);
       return;
     }
@@ -450,6 +453,12 @@ export class RSymbol extends RObject {
 export class RPairlist extends RObject {
   constructor(val: WebRData) {
     if (val instanceof RObjectBase) {
+      if (
+        Module._TYPEOF(val.ptr) !== RTypeMap.pairlist &&
+        Module._TYPEOF(val.ptr) !== RTypeMap.call
+      ) {
+        throw new Error('Unexpected object type in `RPairlist` constructor');
+      }
       super(val);
       return this;
     }
@@ -555,6 +564,9 @@ export class RPairlist extends RObject {
 export class RList extends RObject {
   constructor(val: WebRData) {
     if (val instanceof RObjectBase) {
+      if (Module._TYPEOF(val.ptr) !== RTypeMap.list) {
+        throw new Error('Unexpected object type in `RList` constructor');
+      }
       super(val);
       return this;
     }
@@ -654,6 +666,9 @@ export class RString extends RObject {
   // Unlike symbols, strings are not cached and must thus be protected
   constructor(x: WebRDataScalar<string>) {
     if (x instanceof RObjectBase) {
+      if (Module._TYPEOF(x.ptr) !== RTypeMap.string) {
+        throw new Error('Unexpected object type in `RString` constructor');
+      }
       super(x);
       return;
     }
@@ -682,6 +697,9 @@ export class RString extends RObject {
 export class REnvironment extends RObject {
   constructor(val: WebRData = {}) {
     if (val instanceof RObjectBase) {
+      if (Module._TYPEOF(val.ptr) !== RTypeMap.environment) {
+        throw new Error('Unexpected object type in `REnvironment` constructor');
+      }
       super(val);
       return this;
     }
@@ -887,6 +905,9 @@ abstract class RVectorAtomic<T extends atomicType> extends RObject {
 
 export class RLogical extends RVectorAtomic<boolean> {
   constructor(val: WebRDataAtomic<boolean>) {
+    if (val instanceof RObjectBase && Module._TYPEOF(val.ptr) !== RTypeMap.logical) {
+      throw new Error('Unexpected object type in `RLogical` constructor');
+    }
     super(val, RTypeMap.logical, RLogical.#newSetter);
   }
 
@@ -930,6 +951,9 @@ export class RLogical extends RVectorAtomic<boolean> {
 
 export class RInteger extends RVectorAtomic<number> {
   constructor(val: WebRDataAtomic<number>) {
+    if (val instanceof RObjectBase && Module._TYPEOF(val.ptr) !== RTypeMap.integer) {
+      throw new Error('Unexpected object type in `RInteger` constructor');
+    }
     super(val, RTypeMap.integer, RInteger.#newSetter);
   }
 
@@ -968,6 +992,9 @@ export class RInteger extends RVectorAtomic<number> {
 
 export class RDouble extends RVectorAtomic<number> {
   constructor(val: WebRDataAtomic<number>) {
+    if (val instanceof RObjectBase && Module._TYPEOF(val.ptr) !== RTypeMap.double) {
+      throw new Error('Unexpected object type in `RDouble` constructor');
+    }
     super(val, RTypeMap.double, RDouble.#newSetter);
   }
 
@@ -1003,6 +1030,9 @@ export class RDouble extends RVectorAtomic<number> {
 
 export class RComplex extends RVectorAtomic<Complex> {
   constructor(val: WebRDataAtomic<Complex>) {
+    if (val instanceof RObjectBase && Module._TYPEOF(val.ptr) !== RTypeMap.complex) {
+      throw new Error('Unexpected object type in `RComplex` constructor');
+    }
     super(val, RTypeMap.complex, RComplex.#newSetter);
   }
 
@@ -1049,6 +1079,9 @@ export class RComplex extends RVectorAtomic<Complex> {
 
 export class RCharacter extends RVectorAtomic<string> {
   constructor(val: WebRDataAtomic<string>) {
+    if (val instanceof RObjectBase && Module._TYPEOF(val.ptr) !== RTypeMap.character) {
+      throw new Error('Unexpected object type in `RCharacter` constructor');
+    }
     super(val, RTypeMap.character, RCharacter.#newSetter);
   }
 
@@ -1095,6 +1128,9 @@ export class RCharacter extends RVectorAtomic<string> {
 
 export class RRaw extends RVectorAtomic<number> {
   constructor(val: WebRDataAtomic<number>) {
+    if (val instanceof RObjectBase && Module._TYPEOF(val.ptr) !== RTypeMap.raw) {
+      throw new Error('Unexpected object type in `RRaw` constructor');
+    }
     super(val, RTypeMap.raw, RRaw.#newSetter);
   }
 

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -1,5 +1,5 @@
 import { Module } from './emscripten';
-import { Complex, isComplex, NamedEntries, NamedObject, WebRDataRaw } from './robj';
+import { Complex, isComplex, NamedEntries, NamedObject, WebRDataRaw, WebRDataScalar } from './robj';
 import { WebRData, WebRDataAtomic, RPtr, RType, RTypeMap, RTypeNumber } from './robj';
 import { envPoke, parseEvalBare, protect, protectInc, unprotect } from './utils-r';
 import { protectWithIndex, reprotect, unprotectIndex } from './utils-r';
@@ -397,12 +397,12 @@ export class RSymbol extends RObject {
   // Note that symbols don't need to be protected. This also means
   // that allocating symbols in loops with random data is probably a
   // bad idea because this leaks memory.
-  constructor(x: RObject | string) {
+  constructor(x: WebRDataScalar<string>) {
     if (x instanceof RObjectBase) {
       super(x);
       return;
     }
-    const name = Module.allocateUTF8(x);
+    const name = Module.allocateUTF8(x as string);
     try {
       super(new RObjectBase(Module._Rf_install(name)));
     } finally {
@@ -652,13 +652,13 @@ export class RFunction extends RObject {
 
 export class RString extends RObject {
   // Unlike symbols, strings are not cached and must thus be protected
-  constructor(x: RObject | string) {
+  constructor(x: WebRDataScalar<string>) {
     if (x instanceof RObjectBase) {
       super(x);
       return;
     }
 
-    const name = Module.allocateUTF8(x);
+    const name = Module.allocateUTF8(x as string);
 
     try {
       super(new RObjectBase(Module._Rf_mkChar(name)));

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -79,7 +79,7 @@ function newObjectFromArray(arr: WebRData[]) {
   try {
     const call = new RCall([new RSymbol('c'), ...arr]);
     protectInc(call, prot);
-    return call.exec();
+    return call.eval();
   } finally {
     unprotect(prot.n);
   }
@@ -588,7 +588,7 @@ export class RCall extends RObject {
     return RObject.wrap(Module._CDR(this.ptr)) as Nullable<RPairlist>;
   }
 
-  exec(): RObject {
+  eval(): RObject {
     return RObject.wrap(Module._Rf_eval(this.ptr, RObject.baseEnv.ptr));
   }
 }
@@ -673,7 +673,7 @@ export class RFunction extends RObject {
     try {
       const call = new RCall([this, ...args]);
       protectInc(call, prot);
-      return call.exec();
+      return call.eval();
     } finally {
       unprotect(prot.n);
     }

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -80,7 +80,16 @@ export type WebRData =
  * atomic vectors. The parameter T is the JavaScript scalar type associated with
  * the vector.
  */
-export type WebRDataAtomic<T> = T | (T | null)[] | WebRDataTreeAtomic<T> | NamedObject<T | null>;
+export type WebRDataAtomic<T> =
+  | WebRDataScalar<T>
+  | (T | null)[]
+  | WebRDataTreeAtomic<T>
+  | NamedObject<T | null>;
+
+/**
+ * A subset of WebRData for scalar JavaScript objects.
+ */
+export type WebRDataScalar<T> = T | RMain.RObject | RWorker.RObjectBase;
 
 /**
  * Test if an object is of type Complex

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -66,6 +66,7 @@ export class WebR {
   RPairlist;
   REnvironment;
   RSymbol;
+  RString;
   objs: {
     baseEnv: REnvironment;
     globalEnv: REnvironment;
@@ -90,6 +91,7 @@ export class WebR {
     this.RPairlist = newRClassProxy<typeof RWorker.RPairlist, RPairlist>(c, 'pairlist');
     this.REnvironment = newRClassProxy<typeof RWorker.REnvironment, REnvironment>(c, 'environment');
     this.RSymbol = newRClassProxy<typeof RWorker.RSymbol, RSymbol>(c, 'symbol');
+    this.RString = newRClassProxy<typeof RWorker.RString, RString>(c, 'string');
     this.objs = {} as typeof this.objs;
   }
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -5,7 +5,7 @@ import { webRPayloadError } from './payload';
 import { newRProxy, newRClassProxy } from './proxy';
 import { isRObject, RCharacter, RComplex, RDouble } from './robj-main';
 import { REnvironment, RSymbol, RInteger } from './robj-main';
-import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString } from './robj-main';
+import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString, RCall } from './robj-main';
 import * as RWorker from './robj-worker';
 
 export type CaptureROptions = {
@@ -67,6 +67,7 @@ export class WebR {
   REnvironment;
   RSymbol;
   RString;
+  RCall;
   objs: {
     baseEnv: REnvironment;
     globalEnv: REnvironment;
@@ -92,6 +93,7 @@ export class WebR {
     this.REnvironment = newRClassProxy<typeof RWorker.REnvironment, REnvironment>(c, 'environment');
     this.RSymbol = newRClassProxy<typeof RWorker.RSymbol, RSymbol>(c, 'symbol');
     this.RString = newRClassProxy<typeof RWorker.RString, RString>(c, 'string');
+    this.RCall = newRClassProxy<typeof RWorker.RCall, RCall>(c, 'call');
     this.objs = {} as typeof this.objs;
   }
 


### PR DESCRIPTION
Based on #136.

Checks the object type during `RObject` subclass construction and rejects objects of incorrect type at runtime by throwing.

Includes minor fixups:
* Expose `RString` on the main thread
* Add `WebRDataScalar` as an abstract way to handle `RObject | string` for both `RMain.RObject` and `RWorker.RObject`.