### PR TITLE
Separate unit tests and linting in TypeScript src

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build webR
         env:
           EMSDK: /opt/emsdk
-        run: make && make check
+        run: make && make check-pr
         shell: bash
       - name: Report code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build webR
         env:
           EMSDK: /opt/emsdk
-        run: make && make check
+        run: make && make check-pr
         shell: bash
       - name: Report code coverage
         uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ docker-container-%:
 
 .PHONY: check
 check:
-	cd src && $(MAKE) check && $(MAKE) check-packages
+	cd src && $(MAKE) check
+
+.PHONY: check-pr
+check-pr:
+	cd src && $(MAKE) lint && $(MAKE) check && $(MAKE) check-packages
 
 .PHONY: clean
 clean: clean-webr

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,10 +30,13 @@ webR/config.ts: webR/config.ts.in
 	sed -e "s|@@BASE_URL@@|$(BASE_URL)|" \
 	  -e "s|@@PKG_BASE_URL@@|$(PKG_BASE_URL)|" webR/config.ts.in > webR/config.ts
 
+.PHONY: lint
+lint: $(DIST)
+	npx eslint $(TS_SOURCES)
+
 .PHONY: check
 check: $(DIST)
 	npx tsc
-	npx eslint $(TS_SOURCES)
 	NODE_V8_COVERAGE=coverage npx c8 node ./node_modules/jest/bin/jest.js \
 	  --config tests/webr.config.js
 


### PR DESCRIPTION
* `make check` runs unit tests.
* `make check-pr` runs the linter, runs unit tests, and tests that the built in R packages run.
* The GitHub actions scripts run the full `make check-pr`.