### PR TITLE
Manage memory with shelters

### DIFF
--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -27,7 +27,7 @@ function resizeTerm() {
     await webR.init();
     const dims = fitAddon.proposeDimensions();
     // TODO: Replace by void version of `evalR()`
-    (await webR.evalR(`options(width=${dims ? dims.cols : 80})`)).destroy();
+    await webR.destroy(await webR.evalR(`options(width=${dims ? dims.cols : 80})`));
   })();
   fitAddon.fit();
 }
@@ -82,7 +82,7 @@ const webR = new WebR({
   const out = await webR.captureR('webr::global_prompt_install()', undefined, {
     withHandlers: false,
   });
-  out.result.destroy();
+  await webR.destroy(out.result);
 
   // Clear the loading message
   term.write('\x1b[2K\r');

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -603,6 +603,17 @@ describe('Garbage collection', () => {
 
     // expect(await shelter.size()).toEqual(0);
   });
+
+  test('Can purge shelters', async () => {
+    const shelter = await new webR.Shelter();
+
+    await shelter.captureR('1');
+    await shelter.captureR('1');
+    expect(await shelter.size()).toEqual(2);
+
+    await shelter.purge();
+    expect(await shelter.size()).toEqual(0);
+  });
 });
 
 afterAll(() => {

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -25,7 +25,7 @@ let initShelterSize = -1;
 
 beforeAll(async () => {
   await webR.init();
-  initShelterSize = await webR.shelter.size();
+  initShelterSize = await webR.globalShelter.size();
 });
 
 // We don't destroy objects during unit tests but when webR starts
@@ -546,23 +546,23 @@ describe('Garbage collection', () => {
   });
 
   test('Objects are protected and destroyed', async () => {
-    const size = await webR.shelter.size();
+    const size = await webR.globalShelter.size();
 
     const x = await webR.evalR('1');
     const y = await webR.evalR('1');
-    expect(await webR.shelter.size()).toEqual(size + 2);
+    expect(await webR.globalShelter.size()).toEqual(size + 2);
 
     await webR.destroy(x);
-    expect(await webR.shelter.size()).toEqual(size + 1);
+    expect(await webR.globalShelter.size()).toEqual(size + 1);
 
-    await webR.shelter.destroy(y);
-    expect(await webR.shelter.size()).toEqual(size);
+    await webR.globalShelter.destroy(y);
+    expect(await webR.globalShelter.size()).toEqual(size);
 
     await expect(webR.destroy(x)).rejects.toThrow("Can't find object in shelter");
   });
 
   test('Objects managed in shelter', async () => {
-    const globalSize = await webR.shelter.size();
+    const globalSize = await webR.globalShelter.size();
 
     const shelter = await new webR.Shelter();
     expect(await shelter.size()).toEqual(0);
@@ -570,7 +570,7 @@ describe('Garbage collection', () => {
     const x = await shelter.evalR('1');
     const y = await shelter.evalR('1');
     expect(await shelter.size()).toEqual(2);
-    expect(await webR.shelter.size()).toEqual(globalSize);
+    expect(await webR.globalShelter.size()).toEqual(globalSize);
 
     await shelter.destroy(x);
     expect(await shelter.size()).toEqual(1);

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -560,6 +560,49 @@ describe('Garbage collection', () => {
 
     await expect(webR.destroy(x)).rejects.toThrow("Can't find object in shelter");
   });
+
+  test('Objects managed in shelter', async () => {
+    const globalSize = await webR.shelter.size();
+
+    const shelter = await new webR.Shelter();
+    expect(await shelter.size()).toEqual(0);
+
+    const x = await shelter.evalR('1');
+    const y = await shelter.evalR('1');
+    expect(await shelter.size()).toEqual(2);
+    expect(await webR.shelter.size()).toEqual(globalSize);
+
+    await shelter.destroy(x);
+    expect(await shelter.size()).toEqual(1);
+
+    await shelter.destroy(y);
+    expect(await shelter.size()).toEqual(0);
+
+    await expect(shelter.destroy(x)).rejects.toThrow("Can't find object in shelter");
+  });
+
+  test('Shelter.CaptureR() protects', async () => {
+    const shelter = await new webR.Shelter();
+
+    const out = await shelter.captureR('1');
+    expect(await shelter.size()).toEqual(1);
+
+    await shelter.destroy(out.result);
+    expect(await shelter.size()).toEqual(0);
+
+    // FIXME: Capturing a message in tests fails (with
+    // `webR.captureR()` too)
+
+    // out = await shelter.captureR('message("foo")');
+    // expect(await shelter.size()).toEqual(2);
+
+    // await shelter.destroy(out.result);
+
+    // const output = out.output as { type: string, data: RObject }[];
+    // await shelter.destroy(output[0].data);
+
+    // expect(await shelter.size()).toEqual(0);
+  });
 });
 
 afterAll(() => {

--- a/src/webR/chan/task-common.ts
+++ b/src/webR/chan/task-common.ts
@@ -31,6 +31,10 @@ export function transfer<T>(obj: T, transfers: Transferable[]): T {
 
 export type UUID = string;
 
+export function isUUID(x: any): x is UUID {
+  return typeof x === 'string' && x.length === UUID_LENGTH;
+}
+
 export const UUID_LENGTH = 63;
 
 export function generateUUID(): UUID {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -5,6 +5,7 @@ import { envPoke, parseEvalBare, protect, protectInc, unprotect } from './utils-
 import { protectWithIndex, reprotect, unprotectIndex } from './utils-r';
 import { isWebRDataTree, WebRDataTree, WebRDataTreeAtomic, WebRDataTreeNode } from './tree';
 import { WebRDataTreeNull, WebRDataTreeString, WebRDataTreeSymbol } from './tree';
+import { isUUID, UUID } from './chan/task-common';
 
 export type RHandle = RObject | RPtr;
 
@@ -23,12 +24,30 @@ function assertRType(obj: RObjectBase, type: RType) {
   }
 }
 
+export type Shelter = null | UUID;
+
 // Use this for implicit protection of objects sent to the main
 // thread. Currently uses the precious list but could use a different
 // mechanism in the future. Unprotection is explicit through
 // `RObject.destroy()`.
-export function keep(x: RHandle) {
+export function keep(shelter: Shelter, x: RHandle) {
+  if (shelter === null) {
+    return;
+  }
+
   Module._R_PreserveObject(handlePtr(x));
+
+  // TODO: Remove when shelter transition is complete
+  if (shelter === undefined) {
+    return;
+  }
+
+  if (isUUID(shelter)) {
+    // TODO
+    return;
+  }
+
+  throw new Error('Unexpected shelter type ' + typeof shelter);
 }
 
 export interface ToTreeOptions {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -25,18 +25,14 @@ function assertRType(obj: RObjectBase, type: RType) {
 }
 
 // TODO: Shelter should be a dictionary not an array
-export type Shelter = null | UUID;
-export const shelters = new Map<UUID, RPtr[]>();
+export type Shelter = UUID;
+export const shelters = new Map<Shelter, RPtr[]>();
 
 // Use this for implicit protection of objects sent to the main
 // thread. Currently uses the precious list but could use a different
 // mechanism in the future. Unprotection is explicit through
 // `Shelter.destroy()`.
 export function keep(shelter: Shelter, x: RHandle) {
-  if (shelter === null) {
-    return;
-  }
-
   const ptr = handlePtr(x);
   Module._R_PreserveObject(ptr);
 
@@ -57,10 +53,6 @@ export function keep(shelter: Shelter, x: RHandle) {
 // users in the main thread to release objects that were automatically
 // protected before being sent away.
 export function destroy(shelter: Shelter, x: RHandle) {
-  if (shelter === null) {
-    throw new Error('TODO');
-  }
-
   const ptr = handlePtr(x);
   Module._R_ReleaseObject(ptr);
 

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -66,6 +66,20 @@ export function destroy(shelter: Shelter, x: RHandle) {
   objs.splice(loc, 1);
 }
 
+export function purge(shelter: Shelter) {
+  const ptrs: RPtr[] = shelters.get(shelter)!;
+
+  for (const ptr of ptrs) {
+    try {
+      Module._R_ReleaseObject(ptr);
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  shelters.set(shelter, []);
+}
+
 export interface ToTreeOptions {
   depth: number;
 }

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -73,7 +73,7 @@ export function purge(shelter: Shelter) {
     try {
       Module._R_ReleaseObject(ptr);
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   }
 

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -25,6 +25,7 @@ function assertRType(obj: RObjectBase, type: RType) {
 }
 
 export type Shelter = null | UUID;
+export const shelters = new Map<UUID, RPtr[]>();
 
 // Use this for implicit protection of objects sent to the main
 // thread. Currently uses the precious list but could use a different
@@ -35,7 +36,8 @@ export function keep(shelter: Shelter, x: RHandle) {
     return;
   }
 
-  Module._R_PreserveObject(handlePtr(x));
+  const ptr = handlePtr(x);
+  Module._R_PreserveObject(ptr);
 
   // TODO: Remove when shelter transition is complete
   if (shelter === undefined) {
@@ -43,7 +45,7 @@ export function keep(shelter: Shelter, x: RHandle) {
   }
 
   if (isUUID(shelter)) {
-    // TODO
+    shelters.get(shelter)!.push(ptr);
     return;
   }
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -231,6 +231,18 @@ export class Shelter {
     this.#initialised = true;
   }
 
+  async purge() {
+    const payload = await this.#chan.request({
+      type: 'shelterPurge',
+      data: this.#id,
+    });
+
+    // FIXME: Should be thrown by the channel
+    if (payload.payloadType === 'err') {
+      throw webRPayloadError(payload);
+    }
+  }
+
   async destroy(x: RObject) {
     const payload = await this.#chan.request({
       type: 'shelterDestroy',

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -55,7 +55,7 @@ const defaultOptions = {
 
 export class WebR {
   #chan: ChannelMain;
-  shelter!: Shelter;
+  globalShelter!: Shelter;
 
   RObject;
   RLogical;
@@ -115,7 +115,7 @@ export class WebR {
       na: (await this.RObject.getStaticPropertyValue('logicalNA')) as RLogical,
     };
 
-    this.shelter = await new this.Shelter();
+    this.globalShelter = await new this.Shelter();
 
     return init;
   }
@@ -151,7 +151,7 @@ export class WebR {
   }
 
   async destroy(x: RObject) {
-    await this.shelter.destroy(x);
+    await this.globalShelter.destroy(x);
   }
 
   async captureR(
@@ -162,11 +162,11 @@ export class WebR {
     result: RObject;
     output: unknown[];
   }> {
-    return this.shelter.captureR(code, env, options);
+    return this.globalShelter.captureR(code, env, options);
   }
 
   async evalR(code: string, env?: REnvironment): Promise<RObject> {
-    return this.shelter.evalR(code, env);
+    return this.globalShelter.evalR(code, env);
   }
 
   FS = {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -7,7 +7,7 @@ import { IN_NODE } from './compat';
 import { replaceInObject, throwUnreachable } from './utils';
 import { WebRPayloadPtr, WebRPayload, isWebRPayloadPtr } from './payload';
 import { RObject, isRObject, REnvironment, RList, getRWorkerClass } from './robj-worker';
-import { RCharacter, RString, keep, Shelter, shelters } from './robj-worker';
+import { RCharacter, RString, keep, destroy, Shelter, shelters } from './robj-worker';
 import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
 import { protectInc, unprotect, parseEvalBare } from './utils-r';
 import { generateUUID, UUID } from './chan/task-common';
@@ -128,6 +128,14 @@ function dispatch(msg: Message): void {
             const size = shelters.get(id)!.length;
 
             write({ payloadType: 'raw', obj: size });
+            break;
+          }
+
+          case 'shelterDestroy': {
+            const data = reqMsg.data as { id: null | UUID; obj: WebRPayloadPtr };
+            destroy(data.id, data.obj.obj.ptr);
+
+            write({ payloadType: 'raw', obj: null });
             break;
           }
 

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -7,7 +7,7 @@ import { IN_NODE } from './compat';
 import { replaceInObject, throwUnreachable } from './utils';
 import { WebRPayloadPtr, WebRPayload, isWebRPayloadPtr } from './payload';
 import { RObject, isRObject, REnvironment, RList, getRWorkerClass } from './robj-worker';
-import { RCharacter, RString, keep, destroy, Shelter, shelters } from './robj-worker';
+import { RCharacter, RString, keep, destroy, purge, Shelter, shelters } from './robj-worker';
 import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
 import { protectInc, unprotect, parseEvalBare } from './utils-r';
 import { generateUUID, UUID } from './chan/task-common';
@@ -128,6 +128,14 @@ function dispatch(msg: Message): void {
             const size = shelters.get(id)!.length;
 
             write({ payloadType: 'raw', obj: size });
+            break;
+          }
+
+          case 'shelterPurge': {
+            const shelter = reqMsg.data as Shelter;
+            purge(shelter);
+
+            write({ payloadType: 'raw', obj: null });
             break;
           }
 

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -132,7 +132,7 @@ function dispatch(msg: Message): void {
           }
 
           case 'shelterDestroy': {
-            const data = reqMsg.data as { id: null | UUID; obj: WebRPayloadPtr };
+            const data = reqMsg.data as { id: Shelter; obj: WebRPayloadPtr };
             destroy(data.id, data.obj.obj.ptr);
 
             write({ payloadType: 'raw', obj: null });

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -7,9 +7,10 @@ import { IN_NODE } from './compat';
 import { replaceInObject, throwUnreachable } from './utils';
 import { WebRPayloadPtr, WebRPayload, isWebRPayloadPtr } from './payload';
 import { RObject, isRObject, REnvironment, RList, getRWorkerClass } from './robj-worker';
-import { RCharacter, RString, keep } from './robj-worker';
+import { RCharacter, RString, keep, Shelter } from './robj-worker';
 import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
 import { protectInc, unprotect, parseEvalBare } from './utils-r';
+import { generateUUID, UUID } from './chan/task-common';
 
 let initialised = false;
 let chan: ChannelWorker | undefined;
@@ -41,6 +42,7 @@ type XHRResponse = {
 };
 
 let _config: Required<WebROptions>;
+const shelters = new Map<UUID, RObject[]>();
 
 function dispatch(msg: Message): void {
   switch (msg.type) {
@@ -111,13 +113,26 @@ function dispatch(msg: Message): void {
             break;
           }
 
+          case 'newShelter': {
+            const id = generateUUID();
+            shelters.set(id, []);
+
+            write({
+              payloadType: 'raw',
+              obj: id,
+            });
+            break;
+          }
+
           case 'captureR': {
             const data = reqMsg.data as {
               code: string;
               env?: WebRPayloadPtr;
               options: CaptureROptions;
+              shelter: Shelter;
             };
 
+            const shelter = data.shelter;
             const prot = { n: 0 };
 
             try {
@@ -127,7 +142,7 @@ function dispatch(msg: Message): void {
               const result = capture.get('result');
               const outputs = capture.get(2) as RList;
 
-              keep(result);
+              keep(shelter, result);
 
               const n = outputs.length;
               const output: any[] = [];
@@ -141,7 +156,7 @@ function dispatch(msg: Message): void {
                   const msg = (data as RString).toString();
                   output.push({ type, data: msg });
                 } else {
-                  keep(data);
+                  keep(shelter, data);
                   const payload = {
                     obj: {
                       ptr: data.ptr,
@@ -180,10 +195,11 @@ function dispatch(msg: Message): void {
             const data = reqMsg.data as {
               code: string;
               env?: WebRPayloadPtr;
+              shelter: Shelter;
             };
 
             const result = evalR(data.code, data.env);
-            keep(result);
+            keep(data.shelter, result);
 
             write({
               obj: {
@@ -200,10 +216,11 @@ function dispatch(msg: Message): void {
             const data = reqMsg.data as {
               obj: WebRData;
               objType: RType | 'object';
+              shelter: Shelter;
             };
 
             const payload = newRObject(data.obj, data.objType);
-            keep(payload.obj.ptr);
+            keep(data.shelter, payload.obj.ptr);
 
             write(payload);
             break;
@@ -214,12 +231,13 @@ function dispatch(msg: Message): void {
               payload?: WebRPayloadPtr;
               prop: string;
               args: WebRPayload[];
+              shelter: Shelter;
             };
             const obj = data.payload ? RObject.wrap(data.payload.obj.ptr) : RObject;
 
             const payload = callRObjectMethod(obj, data.prop, data.args);
             if (isWebRPayloadPtr(payload)) {
-              keep(payload.obj.ptr);
+              keep(data.shelter, payload.obj.ptr);
             }
 
             write(payload);
@@ -227,18 +245,12 @@ function dispatch(msg: Message): void {
           }
 
           case 'installPackage': {
-            const res = evalR(
-              `webr::install("${reqMsg.data.name as string}", repos="${_config.PKG_URL}")`
-            );
-            keep(res);
+            // TODO: Use `evalRVoid()`
+            evalR(`webr::install("${reqMsg.data.name as string}", repos="${_config.PKG_URL}")`);
 
             write({
-              obj: {
-                type: res.type(),
-                ptr: res.ptr,
-                methods: RObject.getMethods(res),
-              },
-              payloadType: 'ptr',
+              obj: true,
+              payloadType: 'raw',
             });
             break;
           }
@@ -424,7 +436,7 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
 }
 
 function evalR(code: string, env?: WebRPayloadPtr): RObject {
-  const capture = captureR(code, env);
+  const capture = captureR(code, env, undefined);
   Module._Rf_protect(capture.ptr);
 
   try {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -7,7 +7,7 @@ import { IN_NODE } from './compat';
 import { replaceInObject, throwUnreachable } from './utils';
 import { WebRPayloadPtr, WebRPayload, isWebRPayloadPtr } from './payload';
 import { RObject, isRObject, REnvironment, RList, getRWorkerClass } from './robj-worker';
-import { RCharacter, RString, keep, Shelter } from './robj-worker';
+import { RCharacter, RString, keep, Shelter, shelters } from './robj-worker';
 import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
 import { protectInc, unprotect, parseEvalBare } from './utils-r';
 import { generateUUID, UUID } from './chan/task-common';
@@ -42,7 +42,6 @@ type XHRResponse = {
 };
 
 let _config: Required<WebROptions>;
-const shelters = new Map<UUID, RObject[]>();
 
 function dispatch(msg: Message): void {
   switch (msg.type) {
@@ -121,6 +120,14 @@ function dispatch(msg: Message): void {
               payloadType: 'raw',
               obj: id,
             });
+            break;
+          }
+
+          case 'shelterSize': {
+            const id = reqMsg.data as UUID;
+            const size = shelters.get(id)!.length;
+
+            write({ payloadType: 'raw', obj: size });
             break;
           }
 


### PR DESCRIPTION
Part of #128

- New `WebR.Shelter` async class
- A global shelter is instantiated on init.
- `webR.evalR()` and `webR.captureR()` are aliases for the corresponding methods of this global shelter.
- Can `destroy()` and `purge()` objects in shelters

TODO:

- Move object construction to shelters
- Support "void" shelters to disable protection