### PR TITLE
Use `R_UnwindProtect` when evaluating R calls

### DIFF
--- a/packages/webr/src/decl/webr-decl.h
+++ b/packages/webr/src/decl/webr-decl.h
@@ -1,0 +1,5 @@
+static
+void safe_eval_cleanup(void* cdata, Rboolean jump);
+
+static
+SEXP safe_eval_body(void* data);

--- a/packages/webr/src/webr.c
+++ b/packages/webr/src/webr.c
@@ -34,12 +34,14 @@ struct safe_eval_data {
 };
 
 SEXP ffi_safe_eval(SEXP call, SEXP env) {
+  // Unprotected in the R_UnwindProtect cleanup callback
   SEXP data = PROTECT(Rf_allocVector(RAWSXP, sizeof(struct safe_eval_data)));
 
   struct safe_eval_data* ctx = (struct safe_eval_data *) RAW(data);
   ctx->call = call;
   ctx->env = env;
 
+  // Unprotected in the R_UnwindProtect cleanup callback
   SEXP cont = PROTECT(R_MakeUnwindCont());
   SEXP res = R_UnwindProtect(safe_eval_body, data, safe_eval_cleanup, cont, cont);
   return res;

--- a/packages/webr/src/webr.h
+++ b/packages/webr/src/webr.h
@@ -4,5 +4,6 @@
 #include <Rinternals.h>
 
 SEXP ffi_eval_js(SEXP code);
+SEXP ffi_safe_eval(SEXP call, SEXP env);
 
 #endif

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -109,10 +109,10 @@ describe('Working with R lists and vectors', () => {
 
   test('Get an item using the pluck method', async () => {
     const vector = await webR.evalR('list(a=1, b=list(d="x",e="y",f=list(g=4,h=5,i=c(6,7))), c=3)');
-    let value = (await vector.pluck('b', 'f', 'i', 2)) as RDouble;
+    const value = (await vector.pluck('b', 'f', 'i', 2)) as RDouble;
     expect(await value.toNumber()).toEqual(7);
-    value = (await vector.pluck('b', 'f', 'i', 10)) as RDouble;
-    expect(await value).toBeUndefined();
+    const oob = vector.pluck('b', 'f', 'i', 10);
+    await expect(oob).rejects.toThrow('non-local transfer of control occured');
   });
 
   test('Set an item using the set method', async () => {

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -14,6 +14,7 @@ import {
   REnvironment,
   RCharacter,
   isRObject,
+  RObject,
 } from '../../webR/robj-main';
 
 const webR = new WebR({
@@ -584,24 +585,20 @@ describe('Garbage collection', () => {
   test('Shelter.CaptureR() protects', async () => {
     const shelter = await new webR.Shelter();
 
-    const out = await shelter.captureR('1');
+    let out = await shelter.captureR('1');
     expect(await shelter.size()).toEqual(1);
 
     await shelter.destroy(out.result);
     expect(await shelter.size()).toEqual(0);
 
-    // FIXME: Capturing a message in tests fails (with
-    // `webR.captureR()` too)
+    out = await shelter.captureR('message("foo")');
+    expect(await shelter.size()).toEqual(2);
 
-    // out = await shelter.captureR('message("foo")');
-    // expect(await shelter.size()).toEqual(2);
+    await shelter.destroy(out.result);
 
-    // await shelter.destroy(out.result);
-
-    // const output = out.output as { type: string, data: RObject }[];
-    // await shelter.destroy(output[0].data);
-
-    // expect(await shelter.size()).toEqual(0);
+    const output = out.output as { type: string; data: RObject }[];
+    await shelter.destroy(output[0].data);
+    expect(await shelter.size()).toEqual(0);
   });
 
   test('Can purge shelters', async () => {

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -111,8 +111,16 @@ describe('Working with R lists and vectors', () => {
     const vector = await webR.evalR('list(a=1, b=list(d="x",e="y",f=list(g=4,h=5,i=c(6,7))), c=3)');
     const value = (await vector.pluck('b', 'f', 'i', 2)) as RDouble;
     expect(await value.toNumber()).toEqual(7);
-    const oob = vector.pluck('b', 'f', 'i', 10);
+  });
+
+  test('Throw an error when out of bounds using the pluck method', async () => {
+    const vector = await webR.evalR('list(a=1, b=2, c=3)');
+    const oob = vector.pluck(10);
     await expect(oob).rejects.toThrow('non-local transfer of control occured');
+
+    const lastMsg = (await webR.flush()).pop();
+    expect(lastMsg!.type).toEqual('stderr');
+    expect(lastMsg!.data).toContain('subscript out of bounds');
   });
 
   test('Set an item using the set method', async () => {

--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -1,4 +1,5 @@
 import type { RPtr, RTypeNumber } from './robj';
+import type { UnwindProtectException } from './utils-r';
 
 export interface Module extends EmscriptenModule {
   /* Add mkdirTree to FS namespace, missing from @types/emscripten at the
@@ -8,6 +9,10 @@ export interface Module extends EmscriptenModule {
     mkdirTree(path: string): void;
   };
   ENV: { [key: string]: string };
+  LDSO: {
+    loadedLibsByName: { [key: string]: any };
+    loadedLibsByHandle: { [key: number]: any };
+  };
   monitorRunDependencies: (n: number) => void;
   noImageDecoding: boolean;
   noAudioDecoding: boolean;
@@ -22,7 +27,6 @@ export interface Module extends EmscriptenModule {
     response: string | ArrayBuffer;
   };
   // Exported Emscripten JS API
-  addFunction: typeof addFunction;
   allocateUTF8: typeof allocateUTF8;
   getValue: typeof getValue;
   setValue: typeof setValue;
@@ -56,7 +60,6 @@ export interface Module extends EmscriptenModule {
   _R_ParseEvalString: (code: number, env: RPtr) => RPtr;
   _R_PreserveObject: (ptr: RPtr) => void;
   _R_ReleaseObject: (ptr: RPtr) => void;
-  _R_tryCatchError: (body: RPtr, data: EmPtr, handler: EmPtr, hdata: EmPtr) => RPtr;
   _Rf_ScalarReal: (n: number) => RPtr;
   _Rf_ScalarLogical: (l: number) => RPtr;
   _Rf_ScalarInteger: (n: number) => RPtr;
@@ -81,10 +84,8 @@ export interface Module extends EmscriptenModule {
   _Rf_onintr: () => void;
   _Rf_protect: (ptr: RPtr) => RPtr;
   _R_ContinueUnwind: (cont: RPtr) => never;
-  _R_MakeUnwindCont: () => RPtr;
   _R_ProtectWithIndex: (ptr1: RPtr, ptr2: RPtr) => void;
   _R_Reprotect: (ptr1: RPtr, ptr2: RPtr) => void;
-  _R_UnwindProtect: (fun: RPtr, data: EmPtr, clean: EmPtr, cdata: EmPtr, cont: RPtr) => RPtr;
   _Rf_setAttrib: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr) => RPtr;
   _Rf_unprotect: (n: number) => void;
   _Rf_unprotect_ptr: (ptr: RPtr) => void;
@@ -108,6 +109,7 @@ export interface Module extends EmscriptenModule {
   _SET_VECTOR_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;
   // TODO: Namespace all webR properties
   webr: {
+    UnwindProtectException: typeof UnwindProtectException;
     readConsole: () => number;
     resolveInit: () => void;
     handleEvents: () => void;
@@ -117,7 +119,7 @@ export interface Module extends EmscriptenModule {
 
 export const Module = {} as Module;
 
-export type EmPtr = ReturnType<typeof Module.allocateUTF8>;
+type EmPtr = ReturnType<typeof Module.allocateUTF8>;
 
 export interface DictEmPtrs {
   [key: string]: EmPtr;

--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -80,8 +80,11 @@ export interface Module extends EmscriptenModule {
   _Rf_mkString: (ptr: number) => RPtr;
   _Rf_onintr: () => void;
   _Rf_protect: (ptr: RPtr) => RPtr;
+  _R_ContinueUnwind: (cont: RPtr) => never;
+  _R_MakeUnwindCont: () => RPtr;
   _R_ProtectWithIndex: (ptr1: RPtr, ptr2: RPtr) => void;
   _R_Reprotect: (ptr1: RPtr, ptr2: RPtr) => void;
+  _R_UnwindProtect: (fun: RPtr, data: EmPtr, clean: EmPtr, cdata: EmPtr, cont: RPtr) => RPtr;
   _Rf_setAttrib: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr) => RPtr;
   _Rf_unprotect: (n: number) => void;
   _Rf_unprotect_ptr: (ptr: RPtr) => void;

--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -22,6 +22,7 @@ export interface Module extends EmscriptenModule {
     response: string | ArrayBuffer;
   };
   // Exported Emscripten JS API
+  addFunction: typeof addFunction;
   allocateUTF8: typeof allocateUTF8;
   getValue: typeof getValue;
   setValue: typeof setValue;
@@ -55,6 +56,7 @@ export interface Module extends EmscriptenModule {
   _R_ParseEvalString: (code: number, env: RPtr) => RPtr;
   _R_PreserveObject: (ptr: RPtr) => void;
   _R_ReleaseObject: (ptr: RPtr) => void;
+  _R_tryCatchError: (body: RPtr, data: EmPtr, handler: EmPtr, hdata: EmPtr) => RPtr;
   _Rf_ScalarReal: (n: number) => RPtr;
   _Rf_ScalarLogical: (l: number) => RPtr;
   _Rf_ScalarInteger: (n: number) => RPtr;
@@ -112,7 +114,7 @@ export interface Module extends EmscriptenModule {
 
 export const Module = {} as Module;
 
-type EmPtr = ReturnType<typeof Module.allocateUTF8>;
+export type EmPtr = ReturnType<typeof Module.allocateUTF8>;
 
 export interface DictEmPtrs {
   [key: string]: EmPtr;

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -2,7 +2,7 @@ import { Module } from './emscripten';
 import { Complex, isComplex, NamedEntries, NamedObject, WebRDataRaw, WebRDataScalar } from './robj';
 import { WebRData, WebRDataAtomic, RPtr, RType, RTypeMap, RTypeNumber } from './robj';
 import { envPoke, parseEvalBare, protect, protectInc, unprotect } from './utils-r';
-import { protectWithIndex, reprotect, unprotectIndex, evalCall } from './utils-r';
+import { protectWithIndex, reprotect, unprotectIndex, safeEval } from './utils-r';
 import { ShelterID, isShelterID } from './webr-chan';
 import { isWebRDataTree, WebRDataTree, WebRDataTreeAtomic, WebRDataTreeNode } from './tree';
 import { WebRDataTreeNull, WebRDataTreeString, WebRDataTreeSymbol } from './tree';
@@ -250,7 +250,7 @@ export class RObject extends RObjectBase {
       const call = Module._Rf_lang3(op, this.ptr, idx.ptr);
       protectInc(call, prot);
 
-      return RObject.wrap(evalCall(call, RObject.baseEnv));
+      return RObject.wrap(safeEval(call, RObject.baseEnv));
     } finally {
       unprotect(prot.n);
     }
@@ -267,13 +267,6 @@ export class RObject extends RObjectBase {
       const result = path.reduce(getter, this);
 
       return result.isNull() ? undefined : result;
-    } catch (_e) {
-      const err = _e as Error;
-      // Deal with subscript out of bounds error
-      if (err.message === 'subscript out of bounds') {
-        return undefined;
-      }
-      throw err;
     } finally {
       unprotectIndex(index);
     }
@@ -293,7 +286,7 @@ export class RObject extends RObjectBase {
       const call = Module._Rf_lang4(assign.ptr, this.ptr, idx.ptr, valueObj.ptr);
       protectInc(call, prot);
 
-      return RObject.wrap(evalCall(call, RObject.baseEnv));
+      return RObject.wrap(safeEval(call, RObject.baseEnv));
     } finally {
       unprotect(prot.n);
     }
@@ -586,7 +579,7 @@ export class RCall extends RObject {
   }
 
   eval(): RObject {
-    return RObject.wrap(evalCall(this.ptr, RObject.baseEnv));
+    return RObject.wrap(safeEval(this.ptr, RObject.baseEnv));
   }
 }
 
@@ -865,7 +858,7 @@ abstract class RVectorAtomic<T extends atomicType> extends RObject {
       const call = Module._Rf_lang2(new RSymbol('is.na').ptr, this.ptr);
       protectInc(call, prot);
 
-      const val = RLogical.wrap(evalCall(call, RObject.baseEnv));
+      const val = RLogical.wrap(safeEval(call, RObject.baseEnv));
       protectInc(val, prot);
 
       const ret = val.toTypedArray();

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -10,7 +10,7 @@ import { WebRPayloadPtr, WebRPayload, isWebRPayloadPtr } from './payload';
 import { RObject, isRObject, REnvironment, RList, getRWorkerClass } from './robj-worker';
 import { RCharacter, RString, keep, destroy, purge, shelters } from './robj-worker';
 import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
-import { protectInc, unprotect, parseEvalBare, UnwindProtectException } from './utils-r';
+import { protectInc, unprotect, parseEvalBare, UnwindProtectException, safeEval } from './utils-r';
 import { generateUUID } from './chan/task-common';
 
 import {
@@ -444,8 +444,7 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
     );
     protectInc(call, prot);
 
-    // Call Rf_eval directly here so as to support the option withHandlers: false
-    const capture = RList.wrap(Module._Rf_eval(call, envObj.ptr));
+    const capture = RList.wrap(safeEval(call, envObj.ptr));
     protectInc(capture, prot);
 
     if (_options.captureConditions && _options.throwJsException) {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -436,6 +436,7 @@ function captureR(code: string, env?: WebRPayloadPtr, options: CaptureROptions =
     );
     protectInc(call, prot);
 
+    // Call Rf_eval directly here so as to support the option withHandlers: false
     const capture = RList.wrap(Module._Rf_eval(call, envObj.ptr));
     protectInc(capture, prot);
 
@@ -558,6 +559,7 @@ function init(config: Required<WebROptions>) {
         Module._free(stop);
         Module._free(msg);
 
+        // Call Rf_eval directly here since JS errors are recaptured by R rather than thrown
         Module._Rf_eval(call, RObject.baseEnv.ptr);
       }
       throwUnreachable();


### PR DESCRIPTION
Branched from #139.

This ensures that the stack is only unwound as far as the calling
function, rather than all the way up to the top level, before throwing a
JS Error while evaluating R calls in the worker thread.

This fixes an issue where JS `finally` blocks would continue to try to
unprotect objects after R has already jumped to top level and reset the
protection counter.