### PR TITLE
Add types for channel messages

### DIFF
--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -100,7 +100,7 @@ function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RWorker.RObject>) 
 export function targetMethod(chan: ChannelMain, prop: string): any;
 export function targetMethod(chan: ChannelMain, prop: string, payload: WebRPayloadPtr): any;
 export function targetMethod(chan: ChannelMain, prop: string, payload?: WebRPayloadPtr): any {
-  return async (..._args: unknown[]) => {
+  return async (..._args: WebRData[]) => {
     const args = _args.map((arg) => {
       if (isRObject(arg)) {
         return arg._payload;
@@ -108,12 +108,12 @@ export function targetMethod(chan: ChannelMain, prop: string, payload?: WebRPayl
       return {
         obj: replaceInObject(arg, isRObject, (obj: RObject) => obj._payload),
         payloadType: 'raw',
-      };
+      } as WebRPayload;
     });
 
     const msg: CallRObjectMethodMessage = {
       type: 'callRObjectMethod',
-      data: { payload, prop, args: args as WebRPayload[] },
+      data: { payload, prop, args: args },
     };
     const reply = await chan.request(msg);
 

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -3,9 +3,9 @@ import { Complex, isComplex, NamedEntries, NamedObject, WebRDataRaw, WebRDataSca
 import { WebRData, WebRDataAtomic, RPtr, RType, RTypeMap, RTypeNumber } from './robj';
 import { envPoke, parseEvalBare, protect, protectInc, unprotect } from './utils-r';
 import { protectWithIndex, reprotect, unprotectIndex } from './utils-r';
+import { ShelterID, isShelterID } from './webr-chan';
 import { isWebRDataTree, WebRDataTree, WebRDataTreeAtomic, WebRDataTreeNode } from './tree';
 import { WebRDataTreeNull, WebRDataTreeString, WebRDataTreeSymbol } from './tree';
-import { isUUID, UUID } from './chan/task-common';
 
 export type RHandle = RObject | RPtr;
 
@@ -25,7 +25,6 @@ function assertRType(obj: RObjectBase, type: RType) {
 }
 
 // TODO: Shelter should be a dictionary not an array
-export type ShelterID = UUID;
 export const shelters = new Map<ShelterID, RPtr[]>();
 
 // Use this for implicit protection of objects sent to the main
@@ -41,7 +40,7 @@ export function keep(shelter: ShelterID, x: RHandle) {
     return;
   }
 
-  if (isUUID(shelter)) {
+  if (isShelterID(shelter)) {
     shelters.get(shelter)!.push(ptr);
     return;
   }

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -25,14 +25,14 @@ function assertRType(obj: RObjectBase, type: RType) {
 }
 
 // TODO: Shelter should be a dictionary not an array
-export type Shelter = UUID;
-export const shelters = new Map<Shelter, RPtr[]>();
+export type ShelterID = UUID;
+export const shelters = new Map<ShelterID, RPtr[]>();
 
 // Use this for implicit protection of objects sent to the main
 // thread. Currently uses the precious list but could use a different
 // mechanism in the future. Unprotection is explicit through
 // `Shelter.destroy()`.
-export function keep(shelter: Shelter, x: RHandle) {
+export function keep(shelter: ShelterID, x: RHandle) {
   const ptr = handlePtr(x);
   Module._R_PreserveObject(ptr);
 
@@ -52,7 +52,7 @@ export function keep(shelter: Shelter, x: RHandle) {
 // Frees objects preserved with `keep()`. This method is called by
 // users in the main thread to release objects that were automatically
 // protected before being sent away.
-export function destroy(shelter: Shelter, x: RHandle) {
+export function destroy(shelter: ShelterID, x: RHandle) {
   const ptr = handlePtr(x);
   Module._R_ReleaseObject(ptr);
 
@@ -66,7 +66,7 @@ export function destroy(shelter: Shelter, x: RHandle) {
   objs.splice(loc, 1);
 }
 
-export function purge(shelter: Shelter) {
+export function purge(shelter: ShelterID) {
   const ptrs: RPtr[] = shelters.get(shelter)!;
 
   for (const ptr of ptrs) {

--- a/src/webR/utils.ts
+++ b/src/webR/utils.ts
@@ -23,24 +23,26 @@ export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function replaceInObject(
-  obj: unknown,
+export function replaceInObject<T>(
+  obj: T | T[],
   test: (obj: any) => boolean,
   replacer: (obj: any, ...replacerArgs: any[]) => unknown,
   ...replacerArgs: unknown[]
-): unknown {
+): T | T[] {
   if (obj === null || typeof obj !== 'object') {
     return obj;
   }
   if (test(obj)) {
-    return replacer(obj, ...replacerArgs);
+    return replacer(obj, ...replacerArgs) as T;
   }
   if (Array.isArray(obj) || ArrayBuffer.isView(obj)) {
-    return (obj as unknown[]).map((v) => replaceInObject(v, test, replacer, ...replacerArgs));
+    return (obj as unknown[]).map((v) =>
+      replaceInObject(v, test, replacer, ...replacerArgs)
+    ) as T[];
   }
   return Object.fromEntries(
     Object.entries(obj).map(([k, v], i) => [k, replaceInObject(v, test, replacer, ...replacerArgs)])
-  );
+  ) as T;
 }
 
 /* Workaround for loading a cross-origin script.

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -15,6 +15,24 @@ export interface CallRObjectMethodMessage extends Message {
   };
 }
 
+export type CaptureROptions = {
+  captureStreams?: boolean;
+  captureConditions?: boolean;
+  withAutoprint?: boolean;
+  throwJsException?: boolean;
+  withHandlers?: boolean;
+};
+
+export interface CaptureRMessage extends Message {
+  type: 'captureR';
+  data: {
+    code: string;
+    env?: WebRPayloadPtr;
+    options: CaptureROptions;
+    shelter: ShelterID;
+  };
+}
+
 export interface EvalRMessage extends Message {
   type: 'evalR';
   data: {

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -1,6 +1,7 @@
 import { Message } from './chan/message';
 import { UUID as ShelterID } from './chan/task-common';
 import { WebRPayloadPtr } from './payload';
+import { RType, WebRData } from './robj';
 
 export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';
 
@@ -10,6 +11,15 @@ export interface EvalRMessage extends Message {
     code: string;
     env?: WebRPayloadPtr;
     shelter: ShelterID;
+  };
+}
+
+export interface NewRObjectMessage extends Message {
+  type: 'newRObject';
+  data: {
+    obj: WebRData;
+    objType: RType | 'object';
+    shelter?: ShelterID; // TODO: Remove undefined
   };
 }
 

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -1,9 +1,19 @@
 import { Message } from './chan/message';
 import { UUID as ShelterID } from './chan/task-common';
-import { WebRPayloadPtr } from './payload';
+import { WebRPayload, WebRPayloadPtr } from './payload';
 import { RType, WebRData } from './robj';
 
 export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';
+
+export interface CallRObjectMethodMessage extends Message {
+  type: 'callRObjectMethod';
+  data: {
+    payload?: WebRPayloadPtr;
+    prop: string;
+    args: WebRPayload[];
+    shelter?: ShelterID; // TODO: Remove undefined
+  };
+}
 
 export interface EvalRMessage extends Message {
   type: 'evalR';

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -1,0 +1,1 @@
+export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -24,6 +24,28 @@ export interface EvalRMessage extends Message {
   };
 }
 
+export interface FSMessage extends Message {
+  type: 'lookupPath' | 'mkdir' | 'rmdir' | 'unlink';
+  data: { path: string };
+}
+
+export interface FSReadFileMessage extends Message {
+  type: 'readFile';
+  data: {
+    path: string;
+    flags?: string;
+  };
+}
+
+export interface FSWriteFileMessage extends Message {
+  type: 'writeFile';
+  data: {
+    path: string;
+    data: ArrayBufferView;
+    flags?: string;
+  };
+}
+
 export interface NewRObjectMessage extends Message {
   type: 'newRObject';
   data: {

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -1,1 +1,28 @@
+import { Message } from './chan/message';
+import { UUID as ShelterID } from './chan/task-common';
+import { WebRPayloadPtr } from './payload';
+
 export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';
+
+export interface EvalRMessage extends Message {
+  type: 'evalR';
+  data: {
+    code: string;
+    env?: WebRPayloadPtr;
+    shelter: ShelterID;
+  };
+}
+
+export interface NewShelterMessage extends Message {
+  type: 'newShelter';
+}
+
+export interface ShelterMessage extends Message {
+  type: 'shelterPurge' | 'shelterSize';
+  data: ShelterID;
+}
+
+export interface ShelterDestroyMessage extends Message {
+  type: 'shelterDestroy';
+  data: { id: ShelterID; obj: WebRPayloadPtr };
+}

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -8,6 +8,16 @@ import { REnvironment, RSymbol, RInteger } from './robj-main';
 import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString, RCall } from './robj-main';
 import * as RWorker from './robj-worker';
 
+import {
+  EvalRMessage,
+  FSMessage,
+  FSReadFileMessage,
+  FSWriteFileMessage,
+  NewShelterMessage,
+  ShelterMessage,
+  ShelterDestroyMessage,
+} from './webr-chan';
+
 export type CaptureROptions = {
   captureStreams?: boolean;
   captureConditions?: boolean;
@@ -171,53 +181,52 @@ export class WebR {
 
   FS = {
     lookupPath: async (path: string): Promise<FSNode> => {
-      const payload = await this.#chan.request({ type: 'lookupPath', data: { path } });
+      const msg: FSMessage = { type: 'lookupPath', data: { path } };
+      const payload = await this.#chan.request(msg);
       if (payload.payloadType === 'err') {
         throw webRPayloadError(payload);
       }
       return payload.obj as FSNode;
     },
     mkdir: async (path: string): Promise<FSNode> => {
-      const payload = await this.#chan.request({ type: 'mkdir', data: { path } });
+      const msg: FSMessage = { type: 'mkdir', data: { path } };
+      const payload = await this.#chan.request(msg);
       if (payload.payloadType === 'err') {
         throw webRPayloadError(payload);
       }
       return payload.obj as FSNode;
     },
     readFile: async (path: string, flags?: string): Promise<Uint8Array> => {
-      const payload = await this.#chan.request({ type: 'readFile', data: { path, flags } });
+      const msg: FSReadFileMessage = { type: 'readFile', data: { path, flags } };
+      const payload = await this.#chan.request(msg);
       if (payload.payloadType === 'err') {
         throw webRPayloadError(payload);
       }
       return payload.obj as Uint8Array;
     },
     rmdir: async (path: string): Promise<void> => {
-      const payload = await this.#chan.request({ type: 'rmdir', data: { path } });
+      const msg: FSMessage = { type: 'rmdir', data: { path } };
+      const payload = await this.#chan.request(msg);
       if (payload.payloadType === 'err') {
         throw webRPayloadError(payload);
       }
     },
     writeFile: async (path: string, data: ArrayBufferView, flags?: string): Promise<void> => {
-      const payload = await this.#chan.request({ type: 'writeFile', data: { path, data, flags } });
+      const msg: FSWriteFileMessage = { type: 'writeFile', data: { path, data, flags } };
+      const payload = await this.#chan.request(msg);
       if (payload.payloadType === 'err') {
         throw webRPayloadError(payload);
       }
     },
     unlink: async (path: string): Promise<void> => {
-      const payload = await this.#chan.request({ type: 'unlink', data: { path } });
+      const msg: FSMessage = { type: 'unlink', data: { path } };
+      const payload = await this.#chan.request(msg);
       if (payload.payloadType === 'err') {
         throw webRPayloadError(payload);
       }
     },
   };
 }
-
-import {
-  EvalRMessage,
-  NewShelterMessage,
-  ShelterMessage,
-  ShelterDestroyMessage,
-} from './webr-chan';
 
 export class Shelter {
   #id = '';

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -212,6 +212,13 @@ export class WebR {
   };
 }
 
+import {
+  EvalRMessage,
+  NewShelterMessage,
+  ShelterMessage,
+  ShelterDestroyMessage,
+} from './webr-chan';
+
 export class Shelter {
   #id = '';
   #chan: ChannelMain;
@@ -226,16 +233,18 @@ export class Shelter {
       return;
     }
 
-    const payload = await this.#chan.request({ type: 'newShelter' });
+    const msg = { type: 'newShelter' } as NewShelterMessage;
+    const payload = await this.#chan.request(msg);
     this.#id = payload.obj as string;
     this.#initialised = true;
   }
 
   async purge() {
-    const payload = await this.#chan.request({
+    const msg: ShelterMessage = {
       type: 'shelterPurge',
       data: this.#id,
-    });
+    };
+    const payload = await this.#chan.request(msg);
 
     // FIXME: Should be thrown by the channel
     if (payload.payloadType === 'err') {
@@ -244,10 +253,11 @@ export class Shelter {
   }
 
   async destroy(x: RObject) {
-    const payload = await this.#chan.request({
+    const msg: ShelterDestroyMessage = {
       type: 'shelterDestroy',
       data: { id: this.#id, obj: x._payload },
-    });
+    };
+    const payload = await this.#chan.request(msg);
 
     // FIXME: Should be thrown by the channel
     if (payload.payloadType === 'err') {
@@ -256,10 +266,11 @@ export class Shelter {
   }
 
   async size(): Promise<number> {
-    const payload = await this.#chan.request({
+    const msg: ShelterMessage = {
       type: 'shelterSize',
       data: this.#id,
-    });
+    };
+    const payload = await this.#chan.request(msg);
 
     return payload.obj as number;
   }
@@ -269,10 +280,11 @@ export class Shelter {
       throw new Error('Attempted to evaluate R code with invalid environment object');
     }
 
-    const payload = await this.#chan.request({
+    const msg: EvalRMessage = {
       type: 'evalR',
       data: { code: code, env: env?._payload, shelter: this.#id },
-    });
+    };
+    const payload = await this.#chan.request(msg);
 
     switch (payload.payloadType) {
       case 'raw':

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -9,6 +9,8 @@ import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString, RCall } from
 import * as RWorker from './robj-worker';
 
 import {
+  CaptureRMessage,
+  CaptureROptions,
   EvalRMessage,
   FSMessage,
   FSReadFileMessage,
@@ -17,14 +19,6 @@ import {
   ShelterMessage,
   ShelterDestroyMessage,
 } from './webr-chan';
-
-export type CaptureROptions = {
-  captureStreams?: boolean;
-  captureConditions?: boolean;
-  withAutoprint?: boolean;
-  throwJsException?: boolean;
-  withHandlers?: boolean;
-};
 
 export { Console, ConsoleCallbacks } from '../console/console';
 
@@ -317,7 +311,7 @@ export class Shelter {
       throw new Error('Attempted to evaluate R code with invalid environment object');
     }
 
-    const payload = await this.#chan.request({
+    const msg: CaptureRMessage = {
       type: 'captureR',
       data: {
         code: code,
@@ -325,7 +319,8 @@ export class Shelter {
         options: options,
         shelter: this.#id,
       },
-    });
+    };
+    const payload = await this.#chan.request(msg);
 
     switch (payload.payloadType) {
       case 'ptr':

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -47,6 +47,9 @@ let _config: Required<WebROptions>;
 import {
   CallRObjectMethodMessage,
   EvalRMessage,
+  FSMessage,
+  FSReadFileMessage,
+  FSWriteFileMessage,
   NewRObjectMessage,
   ShelterMessage,
   ShelterDestroyMessage,
@@ -63,7 +66,8 @@ function dispatch(msg: Message): void {
       try {
         switch (reqMsg.type) {
           case 'lookupPath': {
-            const node = Module.FS.lookupPath(reqMsg.data.path as string, {}).node;
+            const msg = reqMsg as FSMessage;
+            const node = Module.FS.lookupPath(msg.data.path, {}).node;
             write({
               obj: copyFSNode(node as FSNode),
               payloadType: 'raw',
@@ -71,17 +75,16 @@ function dispatch(msg: Message): void {
             break;
           }
           case 'mkdir': {
+            const msg = reqMsg as FSMessage;
             write({
-              obj: copyFSNode(Module.FS.mkdir(reqMsg.data.path as string) as FSNode),
+              obj: copyFSNode(Module.FS.mkdir(msg.data.path) as FSNode),
               payloadType: 'raw',
             });
             break;
           }
           case 'readFile': {
-            const reqData = reqMsg.data as {
-              path: string;
-              flags?: string;
-            };
+            const msg = reqMsg as FSReadFileMessage;
+            const reqData = msg.data;
             const out = {
               obj: Module.FS.readFile(reqData.path, {
                 encoding: 'binary',
@@ -93,18 +96,16 @@ function dispatch(msg: Message): void {
             break;
           }
           case 'rmdir': {
+            const msg = reqMsg as FSMessage;
             write({
-              obj: Module.FS.rmdir(reqMsg.data.path as string),
+              obj: Module.FS.rmdir(msg.data.path),
               payloadType: 'raw',
             });
             break;
           }
           case 'writeFile': {
-            const reqData = reqMsg.data as {
-              path: string;
-              data: ArrayBufferView;
-              flags?: string;
-            };
+            const msg = reqMsg as FSWriteFileMessage;
+            const reqData = msg.data;
             // FIXME: Use a replacer + reviver to transfer Uint8Array
             const data = Uint8Array.from(Object.values(reqData.data));
             write({
@@ -114,8 +115,9 @@ function dispatch(msg: Message): void {
             break;
           }
           case 'unlink': {
+            const msg = reqMsg as FSMessage;
             write({
-              obj: Module.FS.unlink(reqMsg.data.path as string),
+              obj: Module.FS.unlink(msg.data.path),
               payloadType: 'raw',
             });
             break;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -44,7 +44,12 @@ type XHRResponse = {
 
 let _config: Required<WebROptions>;
 
-import { EvalRMessage, ShelterMessage, ShelterDestroyMessage } from './webr-chan';
+import {
+  EvalRMessage,
+  NewRObjectMessage,
+  ShelterMessage,
+  ShelterDestroyMessage,
+} from './webr-chan';
 
 function dispatch(msg: Message): void {
   switch (msg.type) {
@@ -235,14 +240,11 @@ function dispatch(msg: Message): void {
           }
 
           case 'newRObject': {
-            const data = reqMsg.data as {
-              obj: WebRData;
-              objType: RType | 'object';
-              shelter: ShelterID;
-            };
+            const msg = reqMsg as NewRObjectMessage;
 
-            const payload = newRObject(data.obj, data.objType);
-            keep(data.shelter, payload.obj.ptr);
+            // TODO: Remove `!`
+            const payload = newRObject(msg.data.obj, msg.data.objType);
+            keep(msg.data.shelter!, payload.obj.ptr);
 
             write(payload);
             break;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -7,9 +7,10 @@ import { IN_NODE } from './compat';
 import { replaceInObject, throwUnreachable } from './utils';
 import { WebRPayloadPtr, WebRPayload, isWebRPayloadPtr } from './payload';
 import { RObject, isRObject, REnvironment, RList, getRWorkerClass } from './robj-worker';
-import { RCharacter, RString, keep, destroy, purge, ShelterID, shelters } from './robj-worker';
+import { RCharacter, RString, keep, destroy, purge, shelters } from './robj-worker';
 import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
 import { protectInc, unprotect, parseEvalBare } from './utils-r';
+import { ShelterID } from './webr-chan';
 import { generateUUID, UUID } from './chan/task-common';
 
 let initialised = false;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -45,6 +45,7 @@ type XHRResponse = {
 let _config: Required<WebROptions>;
 
 import {
+  CallRObjectMethodMessage,
   EvalRMessage,
   NewRObjectMessage,
   ShelterMessage,
@@ -251,17 +252,14 @@ function dispatch(msg: Message): void {
           }
 
           case 'callRObjectMethod': {
-            const data = reqMsg.data as {
-              payload?: WebRPayloadPtr;
-              prop: string;
-              args: WebRPayload[];
-              shelter: ShelterID;
-            };
+            const msg = reqMsg as CallRObjectMethodMessage;
+            const data = msg.data;
             const obj = data.payload ? RObject.wrap(data.payload.obj.ptr) : RObject;
 
             const payload = callRObjectMethod(obj, data.prop, data.args);
             if (isWebRPayloadPtr(payload)) {
-              keep(data.shelter, payload.obj.ptr);
+              // TODO: Remove `!`
+              keep(data.shelter!, payload.obj.ptr);
             }
 
             write(payload);

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -7,7 +7,7 @@ import { IN_NODE } from './compat';
 import { replaceInObject, throwUnreachable } from './utils';
 import { WebRPayloadPtr, WebRPayload, isWebRPayloadPtr } from './payload';
 import { RObject, isRObject, REnvironment, RList, getRWorkerClass } from './robj-worker';
-import { RCharacter, RString, keep, destroy, purge, Shelter, shelters } from './robj-worker';
+import { RCharacter, RString, keep, destroy, purge, ShelterID, shelters } from './robj-worker';
 import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
 import { protectInc, unprotect, parseEvalBare } from './utils-r';
 import { generateUUID, UUID } from './chan/task-common';
@@ -132,7 +132,7 @@ function dispatch(msg: Message): void {
           }
 
           case 'shelterPurge': {
-            const shelter = reqMsg.data as Shelter;
+            const shelter = reqMsg.data as ShelterID;
             purge(shelter);
 
             write({ payloadType: 'raw', obj: null });
@@ -140,7 +140,7 @@ function dispatch(msg: Message): void {
           }
 
           case 'shelterDestroy': {
-            const data = reqMsg.data as { id: Shelter; obj: WebRPayloadPtr };
+            const data = reqMsg.data as { id: ShelterID; obj: WebRPayloadPtr };
             destroy(data.id, data.obj.obj.ptr);
 
             write({ payloadType: 'raw', obj: null });
@@ -152,7 +152,7 @@ function dispatch(msg: Message): void {
               code: string;
               env?: WebRPayloadPtr;
               options: CaptureROptions;
-              shelter: Shelter;
+              shelter: ShelterID;
             };
 
             const shelter = data.shelter;
@@ -218,7 +218,7 @@ function dispatch(msg: Message): void {
             const data = reqMsg.data as {
               code: string;
               env?: WebRPayloadPtr;
-              shelter: Shelter;
+              shelter: ShelterID;
             };
 
             const result = evalR(data.code, data.env);
@@ -239,7 +239,7 @@ function dispatch(msg: Message): void {
             const data = reqMsg.data as {
               obj: WebRData;
               objType: RType | 'object';
-              shelter: Shelter;
+              shelter: ShelterID;
             };
 
             const payload = newRObject(data.obj, data.objType);
@@ -254,7 +254,7 @@ function dispatch(msg: Message): void {
               payload?: WebRPayloadPtr;
               prop: string;
               args: WebRPayload[];
-              shelter: Shelter;
+              shelter: ShelterID;
             };
             const obj = data.payload ? RObject.wrap(data.payload.obj.ptr) : RObject;
 


### PR DESCRIPTION
It is currently tricky to update a message type because the channel erases the types of messages. With this PR we now cast messages to specific types on both sides of the channel to ensure that they match.

The types are imported from a new file 'webr-chan'.

TODO: Add types for responses.