### PR TITLE
Propagate payload errors from channel

### DIFF
--- a/src/webR/chan/channel-common.ts
+++ b/src/webR/chan/channel-common.ts
@@ -1,0 +1,62 @@
+import { SharedBufferChannelMain, SharedBufferChannelWorker } from './channel-shared';
+import { ServiceWorkerChannelMain, ServiceWorkerChannelWorker } from './channel-service';
+import { WebROptions } from '../webr-main';
+import { isCrossOrigin } from '../utils';
+import { IN_NODE } from '../compat';
+
+// This file refers to objects imported from `./channel-shared` and
+// `./channel-service.` These can't be included in `./channel` as this
+// causes a circular dependency issue.
+
+export const ChannelType = {
+  Automatic: 0,
+  SharedArrayBuffer: 1,
+  ServiceWorker: 2,
+} as const;
+
+export type ChannelInitMessage = {
+  type: string;
+  data: {
+    config: Required<WebROptions>;
+    channelType: Exclude<
+      (typeof ChannelType)[keyof typeof ChannelType],
+      typeof ChannelType.Automatic
+    >;
+    clientId?: string;
+    location?: string;
+  };
+};
+
+export function newChannelMain(data: Required<WebROptions>) {
+  switch (data.channelType) {
+    case ChannelType.SharedArrayBuffer:
+      return new SharedBufferChannelMain(data);
+    case ChannelType.ServiceWorker:
+      return new ServiceWorkerChannelMain(data);
+    case ChannelType.Automatic:
+    default:
+      if (IN_NODE || crossOriginIsolated) {
+        return new SharedBufferChannelMain(data);
+      }
+      /*
+       * TODO: If we are not cross-origin isolated but we can still use service
+       * workers, we could setup a service worker to inject the relevant headers
+       * to enable cross-origin isolation.
+       */
+      if ('serviceWorker' in navigator && !isCrossOrigin(data.SW_URL)) {
+        return new ServiceWorkerChannelMain(data);
+      }
+      throw new Error("Can't initialise main thread communication channel");
+  }
+}
+
+export function newChannelWorker(msg: ChannelInitMessage) {
+  switch (msg.data.channelType) {
+    case ChannelType.SharedArrayBuffer:
+      return new SharedBufferChannelWorker();
+    case ChannelType.ServiceWorker:
+      return new ServiceWorkerChannelWorker(msg.data);
+    default:
+      throw new Error('Unknown worker channel type recieved');
+  }
+}

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -177,47 +177,29 @@ export class WebR {
     lookupPath: async (path: string): Promise<FSNode> => {
       const msg: FSMessage = { type: 'lookupPath', data: { path } };
       const payload = await this.#chan.request(msg);
-      if (payload.payloadType === 'err') {
-        throw webRPayloadError(payload);
-      }
       return payload.obj as FSNode;
     },
     mkdir: async (path: string): Promise<FSNode> => {
       const msg: FSMessage = { type: 'mkdir', data: { path } };
       const payload = await this.#chan.request(msg);
-      if (payload.payloadType === 'err') {
-        throw webRPayloadError(payload);
-      }
       return payload.obj as FSNode;
     },
     readFile: async (path: string, flags?: string): Promise<Uint8Array> => {
       const msg: FSReadFileMessage = { type: 'readFile', data: { path, flags } };
       const payload = await this.#chan.request(msg);
-      if (payload.payloadType === 'err') {
-        throw webRPayloadError(payload);
-      }
       return payload.obj as Uint8Array;
     },
     rmdir: async (path: string): Promise<void> => {
       const msg: FSMessage = { type: 'rmdir', data: { path } };
-      const payload = await this.#chan.request(msg);
-      if (payload.payloadType === 'err') {
-        throw webRPayloadError(payload);
-      }
+      await this.#chan.request(msg);
     },
     writeFile: async (path: string, data: ArrayBufferView, flags?: string): Promise<void> => {
       const msg: FSWriteFileMessage = { type: 'writeFile', data: { path, data, flags } };
-      const payload = await this.#chan.request(msg);
-      if (payload.payloadType === 'err') {
-        throw webRPayloadError(payload);
-      }
+      await this.#chan.request(msg);
     },
     unlink: async (path: string): Promise<void> => {
       const msg: FSMessage = { type: 'unlink', data: { path } };
-      const payload = await this.#chan.request(msg);
-      if (payload.payloadType === 'err') {
-        throw webRPayloadError(payload);
-      }
+      await this.#chan.request(msg);
     },
   };
 }
@@ -247,12 +229,7 @@ export class Shelter {
       type: 'shelterPurge',
       data: this.#id,
     };
-    const payload = await this.#chan.request(msg);
-
-    // FIXME: Should be thrown by the channel
-    if (payload.payloadType === 'err') {
-      throw webRPayloadError(payload);
-    }
+    await this.#chan.request(msg);
   }
 
   async destroy(x: RObject) {
@@ -260,12 +237,7 @@ export class Shelter {
       type: 'shelterDestroy',
       data: { id: this.#id, obj: x._payload },
     };
-    const payload = await this.#chan.request(msg);
-
-    // FIXME: Should be thrown by the channel
-    if (payload.payloadType === 'err') {
-      throw webRPayloadError(payload);
-    }
+    await this.#chan.request(msg);
   }
 
   async size(): Promise<number> {
@@ -274,7 +246,6 @@ export class Shelter {
       data: this.#id,
     };
     const payload = await this.#chan.request(msg);
-
     return payload.obj as number;
   }
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -1,4 +1,5 @@
-import { newChannelMain, ChannelMain, ChannelType } from './chan/channel';
+import { ChannelMain } from './chan/channel';
+import { newChannelMain, ChannelType } from './chan/channel-common';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
 import { WebRPayloadPtr, webRPayloadError } from './payload';

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -1,5 +1,6 @@
 import { loadScript } from './compat';
-import { newChannelWorker, ChannelWorker, ChannelInitMessage } from './chan/channel';
+import { ChannelWorker } from './chan/channel';
+import { newChannelWorker, ChannelInitMessage } from './chan/channel-common';
 import { Message, Request, newResponse } from './chan/message';
 import { FSNode, WebROptions } from './webr-main';
 import { Module } from './emscripten';


### PR DESCRIPTION
Branched from #141.

- Automatically reject the promises of request-response messages when an error payload is returned.
- Transform channels in classes so that common methods may be inherited to reuse code.