### PR TITLE
Simplify converting JS error to R error in evalJS

### DIFF
--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -28,6 +28,7 @@ export interface Module extends EmscriptenModule {
   };
   // Exported Emscripten JS API
   allocateUTF8: typeof allocateUTF8;
+  allocateUTF8OnStack: typeof allocateUTF8OnStack;
   getValue: typeof getValue;
   setValue: typeof setValue;
   UTF8ToString: typeof UTF8ToString;
@@ -67,6 +68,7 @@ export interface Module extends EmscriptenModule {
   _Rf_allocList: (len: number) => RPtr;
   _Rf_allocVector: (type: RTypeNumber, len: number) => RPtr;
   _Rf_defineVar: (symbol: RPtr, value: RPtr, env: RPtr) => void;
+  _Rf_error: (msg: EmPtr) => void;
   _Rf_eval: (call: RPtr, env: RPtr) => RPtr;
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
   _Rf_listAppend: (source: RPtr, target: RPtr) => RPtr;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -567,19 +567,10 @@ function init(config: Required<WebROptions>) {
           Module._R_ContinueUnwind(e.cont);
           throwUnreachable();
         }
-
-        const stop = Module.allocateUTF8('stop');
-        const msg = Module.allocateUTF8(
+        const msg = Module.allocateUTF8OnStack(
           `An error occured during JavaScript evaluation:\n  ${(e as { message: string }).message}`
         );
-
-        const ffiMsg = Module._Rf_protect(Module._Rf_mkString(msg));
-        const call = Module._Rf_protect(Module._Rf_lang2(Module._Rf_install(stop), ffiMsg));
-        Module._free(stop);
-        Module._free(msg);
-
-        // Call Rf_eval directly here since JS errors are recaptured by R rather than thrown
-        Module._Rf_eval(call, RObject.baseEnv.ptr);
+        Module._Rf_error(msg);
       }
       throwUnreachable();
       return 0;


### PR DESCRIPTION
Replaces converting a JS error into an R error by constructing an R `stop()` call, by just calling `Rf_error()` directly.

Uses Emscripten's `allocateUTF8OnStack()`, which I only just discovered, to avoid having to work around not being able `free` an allocated string after `Rf_error()` jumps.