### PR TITLE
Remove handling of error payloads on the main side

### DIFF
--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -1,7 +1,7 @@
 import { promiseHandles, ResolveFn, RejectFn } from '../utils';
 import { AsyncQueue } from './queue';
 import { Message, newRequest, Response } from './message';
-import { WebRPayload, webRPayloadError } from '../payload';
+import { WebRPayload, WebRPayloadWorker, webRPayloadError } from '../payload';
 
 // The channel structure is asymetric:
 //
@@ -64,7 +64,7 @@ export abstract class ChannelMain {
     const handles = this.#parked.get(uuid);
 
     if (handles) {
-      const payload = msg.data.resp as WebRPayload;
+      const payload = msg.data.resp as WebRPayloadWorker;
       this.#parked.delete(uuid);
 
       if (payload.payloadType === 'err') {

--- a/src/webR/payload.ts
+++ b/src/webR/payload.ts
@@ -22,7 +22,11 @@ export type WebRPayloadErr = {
   };
   payloadType: 'err';
 };
-export type WebRPayload = WebRPayloadRaw | WebRPayloadPtr | WebRPayloadErr;
+
+// On the main side we shouldn't see any error payload as these are
+// rethrown as JS exceptions
+export type WebRPayload = WebRPayloadRaw | WebRPayloadPtr;
+export type WebRPayloadWorker = WebRPayloadRaw | WebRPayloadPtr | WebRPayloadErr;
 
 export function webRPayloadError(payload: WebRPayloadErr): Error {
   const e = new Error(payload.obj.message);

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -1,6 +1,6 @@
 import { ChannelMain } from './chan/channel';
 import { replaceInObject } from './utils';
-import { isWebRPayloadPtr, webRPayloadError, WebRPayloadPtr, WebRPayload } from './payload';
+import { isWebRPayloadPtr, WebRPayloadPtr, WebRPayload } from './payload';
 import { RType, WebRData, WebRDataRaw } from './robj';
 import { isRObject, RObject, isRFunction } from './robj-main';
 import * as RWorker from './robj-worker';
@@ -78,9 +78,7 @@ function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RWorker.RObject>) 
     const reply = await chan.request(msg);
 
     // Throw an error if there was some problem accessing the object length
-    if (reply.payloadType === 'err') {
-      throw webRPayloadError(reply);
-    } else if (typeof reply.obj !== 'number') {
+    if (typeof reply.obj !== 'number') {
       throw new Error('Cannot iterate over object, unexpected type for length property.');
     }
 
@@ -120,9 +118,7 @@ export function targetMethod(chan: ChannelMain, prop: string, payload?: WebRPayl
     switch (reply.payloadType) {
       case 'ptr':
         return newRProxy(chan, reply);
-      case 'err':
-        throw webRPayloadError(reply);
-      default: {
+      case 'raw': {
         const proxyReply = replaceInObject(
           reply,
           isWebRPayloadPtr,
@@ -156,9 +152,7 @@ async function newRObject(
   switch (payload.payloadType) {
     case 'raw':
       throw new Error('Unexpected raw payload type returned from newRObject');
-    case 'err':
-      throw webRPayloadError(payload);
-    default:
+    case 'ptr':
       return newRProxy(chan, payload);
   }
 }

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -47,8 +47,10 @@ export type WebRDataRaw =
   | boolean
   | undefined
   | null
+  | void
   | Complex
   | Error
+  | Uint8Array
   | ArrayBuffer
   | ArrayBufferView
   | Array<WebRDataRaw>

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -50,7 +50,6 @@ export type WebRDataRaw =
   | void
   | Complex
   | Error
-  | Uint8Array
   | ArrayBuffer
   | ArrayBufferView
   | Array<WebRDataRaw>

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -1,6 +1,6 @@
 import { Message } from './chan/message';
 import { UUID as ShelterID } from './chan/task-common';
-import { WebRPayload, WebRPayloadPtr } from './payload';
+import { WebRPayloadWorker, WebRPayloadPtr } from './payload';
 import { RType, WebRData } from './robj';
 
 export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';
@@ -10,7 +10,7 @@ export interface CallRObjectMethodMessage extends Message {
   data: {
     payload?: WebRPayloadPtr;
     prop: string;
-    args: WebRPayload[];
+    args: WebRPayloadWorker[];
     shelter?: ShelterID; // TODO: Remove undefined
   };
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -2,7 +2,7 @@ import { ChannelMain } from './chan/channel';
 import { newChannelMain, ChannelType } from './chan/channel-common';
 import { Message } from './chan/message';
 import { BASE_URL, PKG_BASE_URL } from './config';
-import { WebRPayloadPtr, webRPayloadError } from './payload';
+import { WebRPayloadPtr } from './payload';
 import { newRProxy, newRClassProxy } from './proxy';
 import { isRObject, RCharacter, RComplex, RDouble } from './robj-main';
 import { REnvironment, RSymbol, RInteger } from './robj-main';
@@ -293,9 +293,7 @@ export class Shelter {
 
     switch (payload.payloadType) {
       case 'raw':
-        throw new Error('Unexpected raw payload type returned from evalR');
-      case 'err':
-        throw webRPayloadError(payload);
+        throw new Error('Unexpected payload type returned from evalR');
       default:
         return newRProxy(this.#chan, payload);
     }
@@ -326,11 +324,7 @@ export class Shelter {
 
     switch (payload.payloadType) {
       case 'ptr':
-        throw new Error('Unexpected ptr payload type returned from evalR');
-
-      case 'err': {
-        throw webRPayloadError(payload);
-      }
+        throw new Error('Unexpected payload type returned from evalR');
 
       case 'raw': {
         const data = payload.obj as {


### PR DESCRIPTION
Follow up for #142

This removes the notion of an error payload on the main side so that we don't have to handle the error case in switch statements.