### PR TITLE
Add non-sheltered eval methods

### DIFF
--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -26,8 +26,7 @@ function resizeTerm() {
   (async () => {
     await webR.init();
     const dims = fitAddon.proposeDimensions();
-    // TODO: Replace by void version of `evalR()`
-    await webR.destroy(await webR.evalR(`options(width=${dims ? dims.cols : 80})`));
+    await webR.evalRVoid(`options(width=${dims ? dims.cols : 80})`);
   })();
   fitAddon.fit();
 }
@@ -78,7 +77,7 @@ const webR = new WebR({
 
   readline.setCtrlCHandler(() => webR.interrupt());
 
-  // TODO: Replace by void version of `evalR()`
+  // TODO: Replace by void version of `evalR()` once we forward an options object
   const out = await webR.captureR('webr::global_prompt_install()', undefined, {
     withHandlers: false,
   });

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -558,6 +558,12 @@ describe('Access R objects via the main thread object cache', () => {
   });
 });
 
+describe('Evaluate objects without shelters', () => {
+  test('evalRVoid()', async () => {
+    expect(await webR.evalRVoid('NULL')).toEqual(undefined);
+  })
+})
+
 beforeEach(() => {
   jest.restoreAllMocks();
 });

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -559,10 +559,36 @@ describe('Access R objects via the main thread object cache', () => {
 });
 
 describe('Evaluate objects without shelters', () => {
-  test('evalRVoid()', async () => {
+  test('no return', async () => {
     expect(await webR.evalRVoid('NULL')).toEqual(undefined);
-  })
-})
+    expect(await webR.evalRVoid('10')).toEqual(undefined);
+  });
+
+  test('boolean return', async () => {
+    expect(await webR.evalRBoolean('TRUE')).toEqual(true);
+    expect(await webR.evalRBoolean('FALSE')).toEqual(false);
+    expect(webR.evalRBoolean('NULL')).rejects.toThrow("Can't convert");
+    expect(webR.evalRBoolean('NA')).rejects.toThrow("Can't convert");
+  });
+
+  test('numeric return', async () => {
+    expect(await webR.evalRNumber('TRUE')).toEqual(1);
+    expect(await webR.evalRNumber('FALSE')).toEqual(0);
+    expect(await webR.evalRNumber('1L')).toEqual(1);
+    expect(await webR.evalRNumber('1.5')).toEqual(1.5);
+    expect(webR.evalRNumber('NULL')).rejects.toThrow("Can't convert");
+    expect(webR.evalRNumber('NA')).rejects.toThrow("Can't convert");
+    expect(webR.evalRNumber('NA_integer_')).rejects.toThrow("Can't convert");
+  });
+
+  test('string return', async () => {
+    expect(await webR.evalRString('"foo"')).toEqual('foo');
+    expect(await webR.evalRString('""')).toEqual('');
+    expect(webR.evalRString('NULL')).rejects.toThrow("Can't convert");
+    expect(webR.evalRString('NA')).rejects.toThrow("Can't convert");
+    expect(webR.evalRString('NA_character_')).rejects.toThrow("Can't convert");
+  });
+});
 
 beforeEach(() => {
   jest.restoreAllMocks();

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -43,7 +43,7 @@ export interface EvalRMessage extends Message {
   };
 }
 
-export type EvalRMessageOutputType = 'void';
+export type EvalRMessageOutputType = 'void' | 'boolean' | 'number' | 'string';
 
 export interface EvalRMessageRaw extends Message {
   type: 'evalRRaw';

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -39,6 +39,18 @@ export interface EvalRMessage extends Message {
     code: string;
     env?: WebRPayloadPtr;
     shelter: ShelterID;
+    outputType?: EvalRMessageOutputType
+  };
+}
+
+export type EvalRMessageOutputType = 'void';
+
+export interface EvalRMessageRaw extends Message {
+  type: 'evalRRaw';
+  data: {
+    code: string;
+    env?: WebRPayloadPtr;
+    outputType: EvalRMessageOutputType
   };
 }
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -181,6 +181,18 @@ export class WebR {
     return this.#evalRRaw(code, env, 'void');
   }
 
+  async evalRBoolean(code: string, env?: REnvironment) {
+    return this.#evalRRaw(code, env, 'boolean');
+  }
+
+  async evalRNumber(code: string, env?: REnvironment) {
+    return this.#evalRRaw(code, env, 'number');
+  }
+
+  async evalRString(code: string, env?: REnvironment) {
+    return this.#evalRRaw(code, env, 'string');
+  }
+
   async #evalRRaw(
     code: string,
     env: REnvironment | undefined,

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -13,9 +13,11 @@ import {
   CaptureRMessage,
   CaptureROptions,
   EvalRMessage,
+  EvalRMessageRaw,
   FSMessage,
   FSReadFileMessage,
   FSWriteFileMessage,
+  EvalRMessageOutputType,
   NewShelterMessage,
   ShelterMessage,
   ShelterDestroyMessage,
@@ -173,6 +175,33 @@ export class WebR {
 
   async evalR(code: string, env?: REnvironment): Promise<RObject> {
     return this.globalShelter.evalR(code, env);
+  }
+
+  async evalRVoid(code: string, env?: REnvironment) {
+    return this.#evalRRaw(code, env, 'void');
+  }
+
+  async #evalRRaw(
+    code: string,
+    env: REnvironment | undefined,
+    outputType: EvalRMessageOutputType
+  ) {
+    if (env && !isRObject(env)) {
+      throw new Error('Attempted to evaluate R code with invalid environment object');
+    }
+
+    const msg: EvalRMessageRaw = {
+      type: 'evalRRaw',
+      data: { code: code, env: env?._payload, outputType: outputType },
+    };
+    const payload = await this.#chan.request(msg);
+
+    switch (payload.payloadType) {
+      case 'raw':
+        return payload.obj;
+      case 'ptr':
+        throw new Error('Unexpected ptr payload type returned from evalRVoid');
+    }
   }
 
   FS = {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -18,6 +18,7 @@ import {
   CaptureRMessage,
   CaptureROptions,
   EvalRMessage,
+  EvalRMessageRaw,
   FSMessage,
   FSReadFileMessage,
   FSWriteFileMessage,
@@ -236,6 +237,25 @@ function dispatch(msg: Message): void {
                 methods: RObject.getMethods(result),
               },
               payloadType: 'ptr',
+            });
+            break;
+          }
+
+          case 'evalRRaw': {
+            const msg = reqMsg as EvalRMessageRaw;
+            evalR(msg.data.code, msg.data.env);
+
+            let out = undefined;
+            switch (msg.data.outputType) {
+              case 'void':
+                break;
+              default:
+                throw new Error('Unexpected output type in `evalRRaw().');
+            }
+
+            write({
+              obj: out,
+              payloadType: 'raw',
             });
             break;
           }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -270,7 +270,7 @@ function dispatch(msg: Message): void {
                   switch (result.type()) {
                     case 'logical':
                       out = (result as RLogical).toBoolean();
-                      out = +out;
+                      out = Number(out);
                       break;
                     case 'integer':
                       out = (result as RInteger).toNumber();


### PR DESCRIPTION
Branched from #147.

These variants return raw JS objects through the channel and thus do not need memory management on the main side.
This completes the set of memory management features. Closes #128.