### PR TITLE
Move `env` argument to a property of `options` in `evalR` functions

### DIFF
--- a/src/docs/evaluating.qmd
+++ b/src/docs/evaluating.qmd
@@ -22,10 +22,14 @@ to a reference to the result of the computation, given as an
 The `options` argument provides advanced control over how the R code is
 evaluated and captured. For example, this can be used to enable R's
 [autoprint](https://cran.r-project.org/doc/manuals/r-release/R-ints.html#Autoprinting)
-feature. The `env` property of the `options` argument can be set when you wish
+feature.
+
+The `env` property of the `options` argument can be set when you wish
 to evaluate the R code within an R environment, rather than the default global
-environment. This could be used, for example, to avoid variable name clashes
-when evaluating multiple unrelated objects.
+environment. This could be used, for example, to sandbox an evaluation in a
+local environment to avoid `<-` creating variables in the global environment.
+Providing an environment is also a convenient way to pass data from Javascript
+to the R process.
 
 If any error conditions are raised during evaluation, they will be re-thrown as
 JavaScript exceptions. Other conditions and stream output is written to the

--- a/src/docs/evaluating.qmd
+++ b/src/docs/evaluating.qmd
@@ -11,17 +11,21 @@ evaluate R code and retrieve the result of the computation. The method takes two
 arguments,
 
 -   `code` - The R code to evaluate.
--   `env` - Optional: The environment to evaluate in. Default:
-    [`RObject.globalEnv()`](api/js/classes/RWorker.RObject.md#globalenv).
-
-The `env` argument can be set when you wish to evaluate the R code within an R
-environment, rather than the default global environment. This could be used, for
-example, to avoid variable name clashes when evaluating multiple unrelated
-objects.
+-   `options` - Optional: A
+    [`CaptureROptions`](api/js/interfaces/WebRChan.CaptureROptions.md) object
+    controlling how the code is evaluated.
 
 [`WebR.evalR()`](api/js/classes/WebR.WebR.md#evalr) returns a promise resolving
 to a reference to the result of the computation, given as an
 [`RObject`](api/js/modules/RMain.md#robject) proxy.
+
+The `options` argument provides advanced control over how the R code is
+evaluated and captured. For example, this can be used to enable R's
+[autoprint](https://cran.r-project.org/doc/manuals/r-release/R-ints.html#Autoprinting)
+feature. The `env` property of the `options` argument can be set when you wish
+to evaluate the R code within an R environment, rather than the default global
+environment. This could be used, for example, to avoid variable name clashes
+when evaluating multiple unrelated objects.
 
 If any error conditions are raised during evaluation, they will be re-thrown as
 JavaScript exceptions. Other conditions and stream output is written to the
@@ -42,7 +46,7 @@ native JavaScript type, it does not need to be memory managed like an `RObject`
 result.
 
 | Method                                                            | Returned object type |
-|--------------------------------------------------------|------------------------|
+|-----------------------------------------------------|--------------------------|
 | [`WebR.evalRBoolean()`](api/js/classes/WebR.WebR.md#evalrboolean) | `boolean`            |
 | [`WebR.evalRNumber()`](api/js/classes/WebR.WebR.md#evalrnumber)   | `number`             |
 | [`WebR.evalRString()`](api/js/classes/WebR.WebR.md#evalrstring)   | `string`             |
@@ -52,12 +56,12 @@ result.
 
 The [`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer) method can be used
 to both evaluate R code and retrieve the result of the computation, and capture
-any stream output or conditions raised. The method takes three arguments,
+any stream output or conditions raised. The method takes two arguments,
 
 -   `code` - The R code to evaluate
--   `env` - Optional: The environment to evaluate in. Default:
-    [`RObject.globalEnv()`](api/js/classes/RWorker.RObject.md#globalenv).
--   `options` - Optional: Advanced control how the code is evaluated.
+-   `options` - Optional: A
+    [`CaptureROptions`](api/js/interfaces/WebRChan.CaptureROptions.md) object
+    controlling how the code is evaluated.
 
 [`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer) returns a promise
 resolving to a JavaScript object with two properties,
@@ -75,13 +79,6 @@ Any raised conditions are also included as elements of `output` with a `type`
 property of `message`, `warning`, or `error`. A reference to the condition is
 returned in the form of an [`RObject`](api/js/modules/RMain.md#robject) proxy in
 the `data` property.
-
-The `options` argument, with a type of
-[CaptureROptions](api/js/interfaces/WebRChan.CaptureROptions.md), provides
-advanced control over how the R code is evaluated and captured. For example,
-this can be used to enable R's
-[autoprint](https://cran.r-project.org/doc/manuals/r-release/R-ints.html#Autoprinting)
-feature.
 
 ## Setting up an R REPL with `Console` {#console}
 

--- a/src/docs/evaluating.qmd
+++ b/src/docs/evaluating.qmd
@@ -12,7 +12,7 @@ arguments,
 
 -   `code` - The R code to evaluate.
 -   `options` - Optional: A
-    [`CaptureROptions`](api/js/interfaces/WebRChan.CaptureROptions.md) object
+    [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md) object
     controlling how the code is evaluated.
 
 [`WebR.evalR()`](api/js/classes/WebR.WebR.md#evalr) returns a promise resolving
@@ -60,7 +60,7 @@ any stream output or conditions raised. The method takes two arguments,
 
 -   `code` - The R code to evaluate
 -   `options` - Optional: A
-    [`CaptureROptions`](api/js/interfaces/WebRChan.CaptureROptions.md) object
+    [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md) object
     controlling how the code is evaluated.
 
 [`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer) returns a promise

--- a/src/docs/examples.qmd
+++ b/src/docs/examples.qmd
@@ -82,7 +82,7 @@ The optional arguments of
 [`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer) have been designed so
 that the defaults are sufficient for general R evaluation and output capture.
 However, the default behaviour can be changed by passing an `options` argument
-of type [`CaptureROptions`](api/js/interfaces/WebRChan.CaptureROptions.md), if
+of type [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md), if
 required.
 
 ### Executing an R function from JavaScript

--- a/src/docs/examples.qmd
+++ b/src/docs/examples.qmd
@@ -104,6 +104,22 @@ console.log(result.values);
     [0.8414709848078965, 0.9092974268256817, 0.1411200080598672]
 
 
+### Evaluating R code within an environment
+
+The `options` argument of [`WebR.evalR()`](api/js/classes/WebR.WebR.md#evalr)
+can be used to control how R code is executed. In this example the options
+argument is used to create a new environment for the R code to be evaluated in.
+
+``` javascript
+let result = await webR.evalR('foo + bar', { env: { foo: 1234, bar: 1 } });
+let output = await result.toNumber();
+
+console.log(output);
+```
+
+    1235
+
+
 ### Bind a JavaScript object into the R global environment
 
 The following snippet demonstrates binding a JavaScript object into the R global

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -78,7 +78,7 @@ const webR = new WebR({
   readline.setCtrlCHandler(() => webR.interrupt());
 
   // TODO: Replace by void version of `evalR()` once we forward an options object
-  const out = await webR.captureR('webr::global_prompt_install()', undefined, {
+  const out = await webR.captureR('webr::global_prompt_install()', {
     withHandlers: false,
   });
   await webR.destroy(out.result);

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -77,11 +77,7 @@ const webR = new WebR({
 
   readline.setCtrlCHandler(() => webR.interrupt());
 
-  // TODO: Replace by void version of `evalR()` once we forward an options object
-  const out = await webR.captureR('webr::global_prompt_install()', {
-    withHandlers: false,
-  });
-  await webR.destroy(out.result);
+  await webR.evalRVoid('webr::global_prompt_install()', { withHandlers: false });
 
   // Clear the loading message
   term.write('\x1b[2K\r');

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -431,7 +431,7 @@ describe('Working with R environments', () => {
 
   test('Evaluating R code in an environment', async () => {
     const env = (await webR.evalR('x<-new.env();x$a=1;x$b=2;x$.c=3;x')) as REnvironment;
-    const value = (await webR.evalR('b', env)) as RDouble;
+    const value = (await webR.evalR('b', { env })) as RDouble;
     expect(await value.toNumber()).toEqual(2);
   });
 });

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -48,7 +48,7 @@ describe('Test webR simple console input/output', () => {
 
 describe('Evaluate R code', () => {
   test('Evaluate R code without setting up error handlers', async () => {
-    const result = webR.captureR('webr::global_prompt_install()', undefined, {
+    const result = webR.captureR('webr::global_prompt_install()', {
       withHandlers: false,
     });
     await expect(result).resolves.not.toThrow();
@@ -63,7 +63,7 @@ describe('Evaluate R code', () => {
   test('Throw an error if passed an invalid environment object type', async () => {
     const euler = await webR.evalR('0.57722');
     // @ts-expect-error Deliberate type error to test Error thrown
-    await expect(webR.evalR('x', euler)).rejects.toThrow('env argument with invalid SEXP type');
+    await expect(webR.evalR('x', euler)).rejects.toThrow('Unexpected object type');
   });
 
   test('Handle syntax errors in evalR', async () => {
@@ -73,7 +73,7 @@ describe('Evaluate R code', () => {
 
   test('Write to stdout while evaluating R code', async () => {
     await webR.flush();
-    const res = webR.captureR('print("Hello, stdout!")', undefined, {
+    const res = webR.captureR('print("Hello, stdout!")', {
       captureStreams: false,
     });
     await expect(res).resolves.not.toThrow();
@@ -82,7 +82,7 @@ describe('Evaluate R code', () => {
 
   test('Write to stderr while evaluating R code', async () => {
     await webR.flush();
-    const res = webR.captureR('message("Hello, stderr!")', undefined, {
+    const res = webR.captureR('message("Hello, stderr!")', {
       captureStreams: false,
       captureConditions: false,
     });
@@ -129,7 +129,7 @@ describe('Evaluate R code', () => {
   });
 
   test('Capture stdout while capturing R code', async () => {
-    const composite = await webR.captureR('c(1, 2, 4, 6, 12, 24, 36, 48)', undefined, {
+    const composite = await webR.captureR('c(1, 2, 4, 6, 12, 24, 36, 48)', {
       withAutoprint: true,
       captureStreams: true,
     });
@@ -137,7 +137,7 @@ describe('Evaluate R code', () => {
   });
 
   test('Capture stderr while capturing R code', async () => {
-    const res = await webR.captureR('message("Hello, stderr!")', undefined, {
+    const res = await webR.captureR('message("Hello, stderr!")', {
       captureStreams: true,
       captureConditions: false,
     });
@@ -145,7 +145,7 @@ describe('Evaluate R code', () => {
   });
 
   test('Capture conditions while capturing R code', async () => {
-    const res = await webR.captureR('warning("This is a warning message")', undefined, {
+    const res = await webR.captureR('warning("This is a warning message")', {
       captureConditions: true,
     });
     const cond = res.output as { type: string; data: RList }[];

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -54,16 +54,14 @@ describe('Evaluate R code', () => {
     await expect(result).resolves.not.toThrow();
   });
 
-  test('Throw an error if passed an invalid environment', async () => {
-    // @ts-expect-error Deliberate type error to test Error thrown
-    const promise = webR.evalR('3.14159', { env: 42 });
-    await expect(promise).rejects.toThrow('invalid environment object');
+  test('Throw an error if passed invalid environment data', async () => {
+    const promise = webR.evalR('3.14159', { env: ['invalid', 'environment'] });
+    await expect(promise).rejects.toThrow("Can't create object in new environment");
   });
 
   test('Throw an error if passed an invalid environment object type', async () => {
     const euler = await webR.evalR('0.57722');
-    // @ts-expect-error Deliberate type error to test Error thrown
-    await expect(webR.evalR('x', euler)).rejects.toThrow('Unexpected object type');
+    await expect(webR.evalR('x', { env: euler })).rejects.toThrow('Unexpected object type');
   });
 
   test('Handle syntax errors in evalR', async () => {
@@ -500,7 +498,7 @@ describe('Serialise nested R lists, pairlists and vectors unambiguously', () => 
     const jsObj = await rObj.toTree();
     const newRObj = (await new webR.RObject(jsObj)) as RList;
     const env = await new webR.REnvironment({ newRObj, rObj });
-    const identical = (await webR.evalR('identical(rObj, newRObj)', env)) as RLogical;
+    const identical = (await webR.evalR('identical(rObj, newRObj)', { env })) as RLogical;
     expect(await rObj.type()).toEqual('list');
     expect(await identical.toBoolean()).toEqual(true);
   });
@@ -512,7 +510,7 @@ describe('Serialise nested R lists, pairlists and vectors unambiguously', () => 
     const jsObj = await rObj.toTree({ depth: 1 });
     const newRObj = (await new webR.RObject(jsObj)) as RList;
     const env = await new webR.REnvironment({ newRObj, rObj });
-    const identical = (await webR.evalR('identical(rObj, newRObj)', env)) as RLogical;
+    const identical = (await webR.evalR('identical(rObj, newRObj)', { env })) as RLogical;
     expect(await rObj.type()).toEqual('list');
     expect(await identical.toBoolean()).toEqual(true);
   });

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -21,7 +21,7 @@ export interface CallRObjectMethodMessage extends Message {
 /**
  * The configuration settings used when evaluating R code.
  */
-export interface CaptureROptions {
+export interface EvalROptions {
   /**
    * The R environment to evaluate within.
    * Deafult: The global environment.
@@ -58,7 +58,7 @@ export interface CaptureRMessage extends Message {
   type: 'captureR';
   data: {
     code: string;
-    options: CaptureROptions;
+    options: EvalROptions;
     shelter: ShelterID;
   };
 }
@@ -67,7 +67,7 @@ export interface EvalRMessage extends Message {
   type: 'evalR';
   data: {
     code: string;
-    options: CaptureROptions;
+    options: EvalROptions;
     shelter: ShelterID;
     outputType?: EvalRMessageOutputType
   };
@@ -79,7 +79,7 @@ export interface EvalRMessageRaw extends Message {
   type: 'evalRRaw';
   data: {
     code: string;
-    options: CaptureROptions;
+    options: EvalROptions;
     outputType: EvalRMessageOutputType
   };
 }

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -67,7 +67,7 @@ export interface EvalRMessage extends Message {
   type: 'evalR';
   data: {
     code: string;
-    env?: WebRPayloadPtr;
+    options: CaptureROptions;
     shelter: ShelterID;
     outputType?: EvalRMessageOutputType
   };
@@ -79,7 +79,7 @@ export interface EvalRMessageRaw extends Message {
   type: 'evalRRaw';
   data: {
     code: string;
-    env?: WebRPayloadPtr;
+    options: CaptureROptions;
     outputType: EvalRMessageOutputType
   };
 }

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -23,6 +23,11 @@ export interface CallRObjectMethodMessage extends Message {
  */
 export interface CaptureROptions {
   /**
+   * The R environment to evaluate within.
+   * Deafult: The global environment.
+   */
+  env?: WebRData;
+  /**
    * Should the stdout and stderr output streams be captured and returned?
    * Deafult: `true`.
    */
@@ -53,7 +58,6 @@ export interface CaptureRMessage extends Message {
   type: 'captureR';
   data: {
     code: string;
-    env?: WebRPayloadPtr;
     options: CaptureROptions;
     shelter: ShelterID;
   };

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -292,13 +292,13 @@ export class WebR {
   }
 
   /**
-   * Evaluate the given R code, optionally within a given R environment.
+   * Evaluate the given R code, capturing output.
    *
    * Stream outputs and conditions raised during exectution are by default
    * captured and returned as part of the output of this function.
    *
-   * See {@link evalR} for a simpler version of this function that uses the
-   * default options and simply returns the result of the computation.
+   * See {@link evalR} for a simpler version of this function that returns only
+   * the result of the computation.
    *
    * @param {string} code The R code to evaluate.
    * @param {CaptureROptions} [options] Options for the execution environment.
@@ -313,14 +313,13 @@ export class WebR {
   }
 
   /**
-   * Evaluate the given R code, optionally within a given R environment.
+   * Evaluate the given R code.
    *
    * Stream outputs and any conditions raised during exectution are written to
    * the JavaScript console.
    *
    * See {@link captureR} for a version of this function that allows for
-   * configuration of advanced options and for returning outputs as part of the
-   * result.
+   * capturing and returning outputs as part of the result.
    *
    * @param {string} code The R code to evaluate.
    * @param {CaptureROptions} [options] Options for the execution environment.

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -17,16 +17,16 @@ import * as RWorker from './robj-worker';
 
 import {
   CaptureRMessage,
-  CaptureROptions,
   EvalRMessage,
+  EvalRMessageOutputType,
   EvalRMessageRaw,
+  EvalROptions,
   FSMessage,
   FSReadFileMessage,
   FSWriteFileMessage,
-  EvalRMessageOutputType,
   NewShelterMessage,
-  ShelterMessage,
   ShelterDestroyMessage,
+  ShelterMessage,
 } from './webr-chan';
 
 export { Console, ConsoleCallbacks } from '../console/console';
@@ -301,11 +301,11 @@ export class WebR {
    * the result of the computation.
    *
    * @param {string} code The R code to evaluate.
-   * @param {CaptureROptions} [options] Options for the execution environment.
+   * @param {EvalROptions} [options] Options for the execution environment.
    * @return {Promise<{result: RObject, output: unknown[]}>} An object
    * containing the result of the computation and and array of captured output.
    */
-  async captureR(code: string, options: CaptureROptions = {}): Promise<{
+  async captureR(code: string, options: EvalROptions = {}): Promise<{
     result: RObject;
     output: unknown[];
   }> {
@@ -322,38 +322,38 @@ export class WebR {
    * capturing and returning outputs as part of the result.
    *
    * @param {string} code The R code to evaluate.
-   * @param {CaptureROptions} [options] Options for the execution environment.
+   * @param {EvalROptions} [options] Options for the execution environment.
    * @return {Promise<RObject>} The result of the computation.
    */
-  async evalR(code: string, options?: CaptureROptions): Promise<RObject> {
+  async evalR(code: string, options?: EvalROptions): Promise<RObject> {
     return this.globalShelter.evalR(code, options);
   }
 
-  async evalRVoid(code: string, options?: CaptureROptions) {
+  async evalRVoid(code: string, options?: EvalROptions) {
     return this.#evalRRaw(code, options, 'void') as Promise<void>;
   }
 
-  async evalRBoolean(code: string, options?: CaptureROptions) {
+  async evalRBoolean(code: string, options?: EvalROptions) {
     return this.#evalRRaw(code, options, 'boolean') as Promise<boolean>;
   }
 
-  async evalRNumber(code: string, options?: CaptureROptions) {
+  async evalRNumber(code: string, options?: EvalROptions) {
     return this.#evalRRaw(code, options, 'number') as Promise<number>;
   }
 
-  async evalRString(code: string, options?: CaptureROptions) {
+  async evalRString(code: string, options?: EvalROptions) {
     return this.#evalRRaw(code, options, 'string') as Promise<string>;
   }
 
   async #evalRRaw(
     code: string,
-    options: CaptureROptions = {},
+    options: EvalROptions = {},
     outputType: EvalRMessageOutputType
   ) {
     const opts = replaceInObject(options, isRObject, (obj: RObject) => obj._payload);
     const msg: EvalRMessageRaw = {
       type: 'evalRRaw',
-      data: { code: code, options: opts as CaptureROptions, outputType: outputType },
+      data: { code: code, options: opts as EvalROptions, outputType: outputType },
     };
     const payload = await this.#chan.request(msg);
 
@@ -471,11 +471,11 @@ export class Shelter {
     return payload.obj as number;
   }
 
-  async evalR(code: string, options: CaptureROptions = {}): Promise<RObject> {
+  async evalR(code: string, options: EvalROptions = {}): Promise<RObject> {
     const opts = replaceInObject(options, isRObject, (obj: RObject) => obj._payload);
     const msg: EvalRMessage = {
       type: 'evalR',
-      data: { code: code, options: opts as CaptureROptions, shelter: this.#id },
+      data: { code: code, options: opts as EvalROptions, shelter: this.#id },
     };
     const payload = await this.#chan.request(msg);
 
@@ -487,7 +487,7 @@ export class Shelter {
     }
   }
 
-  async captureR(code: string, options: CaptureROptions = {}): Promise<{
+  async captureR(code: string, options: EvalROptions = {}): Promise<{
     result: RObject;
     output: unknown[];
   }> {
@@ -496,7 +496,7 @@ export class Shelter {
       type: 'captureR',
       data: {
         code: code,
-        options: opts as CaptureROptions,
+        options: opts as EvalROptions,
         shelter: this.#id,
       },
     };

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -228,7 +228,7 @@ function dispatch(msg: Message): void {
           case 'evalR': {
             const msg = reqMsg as EvalRMessage;
 
-            const result = evalR(msg.data.code, msg.data.env);
+            const result = evalR(msg.data.code, msg.data.options);
             keep(msg.data.shelter, result);
 
             write({
@@ -244,7 +244,7 @@ function dispatch(msg: Message): void {
 
           case 'evalRRaw': {
             const msg = reqMsg as EvalRMessageRaw;
-            const result = evalR(msg.data.code, msg.data.env);
+            const result = evalR(msg.data.code, msg.data.options);
 
             protect(result);
 
@@ -531,8 +531,8 @@ function captureR(code: string, options: CaptureROptions = {}): RList {
   }
 }
 
-function evalR(code: string, env?: WebRPayloadPtr): RObject {
-  const capture = captureR(code, { env });
+function evalR(code: string, options: CaptureROptions = {}): RObject {
+  const capture = captureR(code, options);
   Module._Rf_protect(capture.ptr);
 
   try {

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -17,7 +17,7 @@ import { generateUUID } from './chan/task-common';
 import {
   CallRObjectMethodMessage,
   CaptureRMessage,
-  CaptureROptions,
+  EvalROptions,
   EvalRMessage,
   EvalRMessageRaw,
   FSMessage,
@@ -468,10 +468,10 @@ function callRObjectMethod(
   return { obj: ret, payloadType: 'raw' };
 }
 
-function captureR(code: string, options: CaptureROptions = {}): RList {
+function captureR(code: string, options: EvalROptions = {}): RList {
   const prot = { n: 0 };
   try {
-    const _options: Required<CaptureROptions> = Object.assign(
+    const _options: Required<EvalROptions> = Object.assign(
       {
         env: RObject.globalEnv,
         captureStreams: true,
@@ -531,7 +531,7 @@ function captureR(code: string, options: CaptureROptions = {}): RList {
   }
 }
 
-function evalR(code: string, options: CaptureROptions = {}): RObject {
+function evalR(code: string, options: EvalROptions = {}): RObject {
   const capture = captureR(code, options);
   Module._Rf_protect(capture.ptr);
 


### PR DESCRIPTION
`CaptureROptions` is changed so that the `env` argument becomes a property of that interface.

`evalR` is changed so that the second argument is the entire `options` object, rather than just `env`. The argument remains optional and, as before, should default to something sensible.

`new REnvironment()` is used on the worker thread to construct the R environment to evaluate within. When passing an existing `REnvironment` this should not change anything, but doing this enables the `env` property to be of type `WebRData` and an environment to be constructed on the fly from JavaScript objects,

`await webR.evalR('foo + bar', { env: { foo: 1234, bar: 1 } })`

I thought this was really neat, so I also added it as an example in the docs as well as updating references to arguments of `evalR()` and `captureR()`.