### PR TITLE
Allow `captureR` only when using a webR shelter

### DIFF
--- a/src/docs/evaluating.qmd
+++ b/src/docs/evaluating.qmd
@@ -15,9 +15,8 @@ arguments,
     [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md) object
     controlling how the code is evaluated.
 
-[`WebR.evalR()`](api/js/classes/WebR.WebR.md#evalr) returns a promise resolving
-to a reference to the result of the computation, given as an
-[`RObject`](api/js/modules/RMain.md#robject) proxy.
+A promise is returned resolving to a reference to the result of the computation,
+given as an [`RObject`](api/js/modules/RMain.md#robject) proxy.
 
 The `options` argument provides advanced control over how the R code is
 evaluated and captured. For example, this can be used to enable R's
@@ -59,20 +58,26 @@ result.
 
 ## Evaluating R code and capturing output with `captureR`
 
-Once a webR [shelter](objects.qmd#shelter) has been created for the purposes of
-[memory management](objects.qmd#memory-management), the
-[`Shelter.captureR()`](api/js/classes/WebR.Shelter.md#capturer) method can be
-used to evaluate R code and capture any stream output or conditions raised in
-addition to returning the result of the computation. The method takes two
-arguments,
+The [`Shelter.captureR()`](api/js/classes/WebR.Shelter.md#capturer) method can
+be used to evaluate R code and capture any stream output or conditions raised in
+addition to returning the result of the computation.
+
+Unlike `evalR()` which only returns one R object, `captureR()` returns a
+variable number of objects when R conditions are captured. This makes memory
+management of individual objects unwieldy. For this reason, `captureR()`
+requires the [shelter](objects.qmd#shelter) approach to
+[memory management](objects.qmd#memory-management), where all the sheltered
+objects are destroyed at once.
+
+The method takes two arguments,
 
 -   `code` - The R code to evaluate
 -   `options` - Optional: A
     [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md) object
     controlling how the code is evaluated.
 
-[`Shelter.captureR()`](api/js/classes/WebR.Shelter.md#capturer) returns a
-promise resolving to a JavaScript object with two properties,
+A promise is returned resolving resolving to a JavaScript object with two
+properties,
 
 -   `result` - The result of the computation, as an
     [`RObject`](api/js/modules/RMain.md#robject) proxy.

--- a/src/docs/evaluating.qmd
+++ b/src/docs/evaluating.qmd
@@ -35,11 +35,12 @@ If any error conditions are raised during evaluation, they will be re-thrown as
 JavaScript exceptions. Other conditions and stream output is written to the
 JavaScript console.
 
-::: callout-warning
-`RObject` references returned by `evalR()` and other methods are subject to R
-[memory management](objects.qmd#memory-management) and should be destroyed when
-no longer in use.
-:::
+`RObject` references returned by `evalR()` are subject to [memory
+management](objects.qmd#memory-management) and should be destroyed when no
+longer in use. The related
+[`Shelter.evalR()`](api/js/classes/WebR.Shelter.md#evalr) method can be used to
+automatically manage returned R objects using a webR
+[shelter](objects.qmd#shelter).
 
 ### Returning JavaScript values when evaluating R code
 
@@ -58,17 +59,20 @@ result.
 
 ## Evaluating R code and capturing output with `captureR`
 
-The [`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer) method can be used
-to both evaluate R code and retrieve the result of the computation, and capture
-any stream output or conditions raised. The method takes two arguments,
+Once a webR [shelter](objects.qmd#shelter) has been created for the purposes of
+[memory management](objects.qmd#memory-management), the
+[`Shelter.captureR()`](api/js/classes/WebR.Shelter.md#capturer) method can be
+used to evaluate R code and capture any stream output or conditions raised in
+addition to returning the result of the computation. The method takes two
+arguments,
 
 -   `code` - The R code to evaluate
 -   `options` - Optional: A
     [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md) object
     controlling how the code is evaluated.
 
-[`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer) returns a promise
-resolving to a JavaScript object with two properties,
+[`Shelter.captureR()`](api/js/classes/WebR.Shelter.md#capturer) returns a
+promise resolving to a JavaScript object with two properties,
 
 -   `result` - The result of the computation, as an
     [`RObject`](api/js/modules/RMain.md#robject) proxy.
@@ -91,7 +95,7 @@ JavaScript callback functions, can be used as an alternative way to use the R
 REPL without directly issuing messages to the webR communication channel.
 
 The issuing of input messages and the consumption of output messages over the
-communication channel between the webR worker thread and the main thead is
+communication channel between the webR worker thread and the main thread is
 handled by [`Console`](api/js/classes/WebR.Console.md), invoking the relevant
 callbacks provided.
 

--- a/src/docs/examples.qmd
+++ b/src/docs/examples.qmd
@@ -57,19 +57,31 @@ console.log('Result of running `rnorm` from webR: ', output);
     6.793839154500917, 5.80036239061935, 5.342100112394279,
     5.555879371932934, 4.314676418095938, 5.113592217724398]
 
+The `options` argument of [`WebR.evalR()`](api/js/classes/WebR.WebR.md#evalr)
+has been designed so that the default is sufficient for general R evaluation.
+However, the default behaviour can be changed by passing an `options` argument
+of type [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md), if
+required.
+
 ### Capturing console output from R code
 
-The following snippet demonstrates capturing R output during evaluation using
-[`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer). This differs
-from the example above in that the output is retrieved in the form of lines of
-text from the `stdout` stream, rather than a reference to an R object [in the
-form of an `RObject` proxy](objects.qmd).
+The following snippet demonstrates using a webR [shelter](objects.qmd#shelter)
+to capture R output during evaluation. This differs from the example above in
+that the output is retrieved in the form of lines of text from the `stdout`
+stream, rather than a reference to an R object [in the form of an `RObject`
+proxy](objects.qmd).
+
+Once the result is no longer needed, the shelter is purged for the purpose of
+[memory management](objects.qmd#memory-management).
 
 ``` javascript
-let result = await webR.captureR('print(rnorm(10,5,1))');
+let shelter = await new webR.Shelter();
+let result = await shelter.captureR('print(rnorm(10,5,1))');
 
 console.log('Output obtained from running `rnorm` from webR:')
 console.log(result.output);
+
+shelter.purge();
 ```
 
     Output obtained from running `rnorm` from webR:
@@ -77,13 +89,6 @@ console.log(result.output);
       {type: 'stdout', data: ' [1] 5.322551 6.924352 4.592612 6.357413 7.198339 5.152446 4.185396'}
       {type: 'stdout', data: ' [8] 4.995504 6.034569 6.295957'}
     ]
-
-The optional arguments of
-[`WebR.captureR()`](api/js/classes/WebR.WebR.md#capturer) have been designed so
-that the defaults are sufficient for general R evaluation and output capture.
-However, the default behaviour can be changed by passing an `options` argument
-of type [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md), if
-required.
 
 ### Executing an R function from JavaScript
 

--- a/src/docs/index.qmd
+++ b/src/docs/index.qmd
@@ -51,18 +51,23 @@ browser, no installation required!
   import { WebR } from 'https://webr.r-wasm.org/v0.1.0/webr.mjs';
   const webR = new WebR();
   await webR.init();
+  const shelter = await new webR.Shelter();
 
   async function runR() {
     let code = editor.getValue();
-    const result = await webR.captureR(code, undefined, {
+    const result = await shelter.captureR(code, undefined, {
       withAutoprint: true,
       captureStreams: true,
       captureConditions: false
     });
-    const out = result.output.filter(
-      evt => evt.type == 'stdout' || evt.type == 'stderr'
-    ).map((evt) => evt.data);
-    document.getElementById('out').innerText = out.join('\n');
+    try {
+      const out = result.output.filter(
+        evt => evt.type == 'stdout' || evt.type == 'stderr'
+      ).map((evt) => evt.data);
+      document.getElementById('out').innerText = out.join('\n');
+    } finally {
+      shelter.purge();
+    }
   }
   document.getElementById('runButton').onclick = runR;
   document.getElementById('runButton').innerText = 'Run code';

--- a/src/docs/objects.qmd
+++ b/src/docs/objects.qmd
@@ -1,8 +1,10 @@
 ---
-title: "R Object References"
+title: "R Object Memory Management"
 format: html
 toc: true
 ---
+
+## References to R objects
 
 When webR provides a reference to an R object on the main thread, such as the
 result of R code evaluation with
@@ -60,7 +62,7 @@ It is the user's responsibility to signal to webR when they have finished
 working with an `RObject` reference.
 :::
 
-## Sheltering R object references
+## Sheltering R object references {#shelter}
 
 WebR solves the problem through a *sheltering* mechanism. When an `RObject`
 reference is created on the main thread, the object referenced is automatically
@@ -135,7 +137,7 @@ provided on the [`WebR`](api/js/classes/WebR.WebR.md#methods) class.
 #### Evaluating under a shelter
 
 The [`Shelter.evalR()`](api/js/classes/WebR.Shelter.md#evalr) and
-[`Shelter.captureR()`](api/js/classes/WebR.Shelter.md#evalr) methods will
+[`Shelter.captureR()`](api/js/classes/WebR.Shelter.md#capturer) methods will
 automatically protect the resulting `RObject` references using this shelter,
 rather than default shelter.
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -292,34 +292,10 @@ export class WebR {
   }
 
   /**
-   * Evaluate the given R code, capturing output.
-   *
-   * Stream outputs and conditions raised during exectution are by default
-   * captured and returned as part of the output of this function.
-   *
-   * See {@link evalR} for a simpler version of this function that returns only
-   * the result of the computation.
-   *
-   * @param {string} code The R code to evaluate.
-   * @param {EvalROptions} [options] Options for the execution environment.
-   * @return {Promise<{result: RObject, output: unknown[]}>} An object
-   * containing the result of the computation and and array of captured output.
-   */
-  async captureR(code: string, options: EvalROptions = {}): Promise<{
-    result: RObject;
-    output: unknown[];
-  }> {
-    return this.globalShelter.captureR(code, options);
-  }
-
-  /**
    * Evaluate the given R code.
    *
    * Stream outputs and any conditions raised during exectution are written to
    * the JavaScript console.
-   *
-   * See {@link captureR} for a version of this function that allows for
-   * capturing and returning outputs as part of the result.
    *
    * @param {string} code The R code to evaluate.
    * @param {EvalROptions} [options] Options for the execution environment.
@@ -471,6 +447,16 @@ export class Shelter {
     return payload.obj as number;
   }
 
+  /**
+   * Evaluate the given R code.
+   *
+   * Stream outputs and any conditions raised during exectution are written to
+   * the JavaScript console. The returned R object is protected by the shelter.
+   *
+   * @param {string} code The R code to evaluate.
+   * @param {EvalROptions} [options] Options for the execution environment.
+   * @return {Promise<RObject>} The result of the computation.
+   */
   async evalR(code: string, options: EvalROptions = {}): Promise<RObject> {
     const opts = replaceInObject(options, isRObject, (obj: RObject) => obj._payload);
     const msg: EvalRMessage = {
@@ -487,6 +473,18 @@ export class Shelter {
     }
   }
 
+  /**
+   * Evaluate the given R code, capturing output.
+   *
+   * Stream outputs and conditions raised during exectution are captured and
+   * returned as part of the output of this function. Returned R objects are
+   * protected by the shelter.
+   *
+   * @param {string} code The R code to evaluate.
+   * @param {EvalROptions} [options] Options for the execution environment.
+   * @return {Promise<{result: RObject, output: unknown[]}>} An object
+   * containing the result of the computation and and array of captured output.
+   */
   async captureR(code: string, options: EvalROptions = {}): Promise<{
     result: RObject;
     output: unknown[];


### PR DESCRIPTION
Remove `webR.captureR()` method and update the documentation to reflect the changes.