### PR TITLE
Expose `evalRRaw()` as part of the webR API, and add support for returning JS arrays.

### DIFF
--- a/src/docs/evaluating.qmd
+++ b/src/docs/evaluating.qmd
@@ -43,11 +43,11 @@ automatically manage returned R objects using a webR
 
 ### Returning JavaScript values when evaluating R code
 
-A selection of convenience methods are provided that return the result of
-evaluating R code as a promise resolving to a JavaScript object, rather than an
-`RObject` reference. The benefit is that since the returned object is of a
-native JavaScript type, it does not need to be memory managed like an `RObject`
-result.
+A selection of convenience methods are available that return the result of
+evaluating R code as a promise resolving to a JavaScript object, rather than
+an `RObject` reference. The benefit is that since the returned object is of a
+raw JavaScript type, it does not need to be memory managed like an `RObject`
+result would be.
 
 | Method                                                            | Returned object type |
 |-----------------------------------------------------|--------------------------|
@@ -55,6 +55,28 @@ result.
 | [`WebR.evalRNumber()`](api/js/classes/WebR.WebR.md#evalrnumber)   | `number`             |
 | [`WebR.evalRString()`](api/js/classes/WebR.WebR.md#evalrstring)   | `string`             |
 | [`WebR.evalRVoid()`](api/js/classes/WebR.WebR.md#evalrvoid)       | No return value      |
+
+The methods in the table above are shortcuts to the more general
+[`WebR.evalRRaw()`](api/js/classes/WebR.WebR.md#evalrraw) method. This takes an
+additional `outputType` argument, which determines the type of raw JavaScript
+object returned. Using the `evalRRaw()` method additionally allows for the
+return of JavaScript `Array` objects.
+
+| `objectType` argument value    | Returned object type |
+|--------------------------------|----------------------|
+| `'boolean'`   | `boolean` |
+| `'number'`    | `number`  |
+| `'string'`    | `string`  |
+| `'boolean[]'` | Array of `boolean` values     |
+| `'number[]'`  | Array of `number` values      |
+| `'string[]'`  | Array of `string` values      |
+| `'void'`      | No return value |
+
+::: callout-warning
+The `evalRRaw()` method and its related convenience methods require that the
+result of the R code evaluation is a vector of type `logical`, `integer`,
+`double` or `character` and must not contain missing values.
+:::
 
 ## Evaluating R code and capturing output with `captureR`
 

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -575,6 +575,13 @@ describe('Evaluate objects without shelters', () => {
     await expect(webR.evalRBoolean('NA')).rejects.toThrow("Can't convert");
   });
 
+  test('boolean array return', async () => {
+    expect(await webR.evalRRaw('c(TRUE, FALSE)', 'boolean[]')).toEqual([true, false]);
+    expect(await webR.evalRRaw('TRUE', 'boolean[]')).toEqual([true]);
+    await expect(webR.evalRRaw('c(TRUE, FALSE, NA)', 'boolean[]')).rejects.toThrow("Can't convert");
+    await expect(webR.evalRRaw('10', 'boolean[]')).rejects.toThrow("Can't convert");
+  });
+
   test('numeric return', async () => {
     expect(await webR.evalRNumber('TRUE')).toEqual(1);
     expect(await webR.evalRNumber('FALSE')).toEqual(0);
@@ -585,12 +592,28 @@ describe('Evaluate objects without shelters', () => {
     await expect(webR.evalRNumber('NA_integer_')).rejects.toThrow("Can't convert");
   });
 
+  test('numeric array return', async () => {
+    expect(await webR.evalRRaw('c(TRUE, FALSE)', 'number[]')).toEqual([1, 0]);
+    expect(await webR.evalRRaw('c(1L, 10L, 100L)', 'number[]')).toEqual([1, 10, 100]);
+    expect(await webR.evalRRaw('c(1.5, 3.5, 7.5)', 'number[]')).toEqual([1.5, 3.5, 7.5]);
+    expect(await webR.evalRRaw('1.5', 'number[]')).toEqual([1.5]);
+    await expect(webR.evalRRaw('NA', 'number[]')).rejects.toThrow("Can't convert");
+    await expect(webR.evalRRaw('"foo"', 'number[]')).rejects.toThrow("Can't convert");
+  });
+
   test('string return', async () => {
     expect(await webR.evalRString('"foo"')).toEqual('foo');
     expect(await webR.evalRString('""')).toEqual('');
     await expect(webR.evalRString('NULL')).rejects.toThrow("Can't convert");
     await expect(webR.evalRString('NA')).rejects.toThrow("Can't convert");
     await expect(webR.evalRString('NA_character_')).rejects.toThrow("Can't convert");
+  });
+
+  test('string array return', async () => {
+    expect(await webR.evalRRaw('c("foo", "bar")', 'string[]')).toEqual(['foo', 'bar']);
+    expect(await webR.evalRRaw('"foo"', 'string[]')).toEqual(['foo']);
+    await expect(webR.evalRRaw('10', 'string[]')).rejects.toThrow("Can't convert");
+    await expect(webR.evalRRaw('NULL', 'string[]')).rejects.toThrow("Can't convert");
   });
 });
 

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -73,7 +73,14 @@ export interface EvalRMessage extends Message {
   };
 }
 
-export type EvalRMessageOutputType = 'void' | 'boolean' | 'number' | 'string';
+export type EvalRMessageOutputType =
+  | 'void'
+  | 'boolean'
+  | 'boolean[]'
+  | 'number'
+  | 'number[]'
+  | 'string'
+  | 'string[]';
 
 export interface EvalRMessageRaw extends Message {
   type: 'evalRRaw';

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -331,8 +331,11 @@ export class WebR {
     */
   async evalRRaw(code: string, outputType: 'void', options?: EvalROptions): Promise<void>;
   async evalRRaw(code: string, outputType: 'boolean', options?: EvalROptions): Promise<boolean>;
+  async evalRRaw(code: string, outputType: 'boolean[]', options?: EvalROptions): Promise<boolean[]>;
   async evalRRaw(code: string, outputType: 'number', options?: EvalROptions): Promise<number>;
+  async evalRRaw(code: string, outputType: 'number[]', options?: EvalROptions): Promise<number[]>;
   async evalRRaw(code: string, outputType: 'string', options?: EvalROptions): Promise<string>;
+  async evalRRaw(code: string, outputType: 'string[]', options?: EvalROptions): Promise<string[]>;
   async evalRRaw(code: string, outputType: EvalRMessageOutputType, options: EvalROptions = {}) {
     const opts = replaceInObject(options, isRObject, (obj: RObject) => obj._payload);
     const msg: EvalRMessageRaw = {

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -306,26 +306,34 @@ export class WebR {
   }
 
   async evalRVoid(code: string, options?: EvalROptions) {
-    return this.#evalRRaw(code, options, 'void') as Promise<void>;
+    return this.evalRRaw(code, 'void', options);
   }
 
   async evalRBoolean(code: string, options?: EvalROptions) {
-    return this.#evalRRaw(code, options, 'boolean') as Promise<boolean>;
+    return this.evalRRaw(code, 'boolean', options);
   }
 
   async evalRNumber(code: string, options?: EvalROptions) {
-    return this.#evalRRaw(code, options, 'number') as Promise<number>;
+    return this.evalRRaw(code, 'number', options);
   }
 
   async evalRString(code: string, options?: EvalROptions) {
-    return this.#evalRRaw(code, options, 'string') as Promise<string>;
+    return this.evalRRaw(code, 'string', options);
   }
 
-  async #evalRRaw(
-    code: string,
-    options: EvalROptions = {},
-    outputType: EvalRMessageOutputType
-  ) {
+  /**
+    * Evaluate the given R code, returning the result as a raw JavaScript object.
+    *
+    * @param {string} code The R code to evaluate.
+    * @param {EvalRMessageOutputType} outputType JavaScript type to return the result as.
+    * @param {EvalROptions} [options] Options for the execution environment.
+    * @return {Promise<unknown>} The result of the computation.
+    */
+  async evalRRaw(code: string, outputType: 'void', options?: EvalROptions): Promise<void>;
+  async evalRRaw(code: string, outputType: 'boolean', options?: EvalROptions): Promise<boolean>;
+  async evalRRaw(code: string, outputType: 'number', options?: EvalROptions): Promise<number>;
+  async evalRRaw(code: string, outputType: 'string', options?: EvalROptions): Promise<string>;
+  async evalRRaw(code: string, outputType: EvalRMessageOutputType, options: EvalROptions = {}) {
     const opts = replaceInObject(options, isRObject, (obj: RObject) => obj._payload);
     const msg: EvalRMessageRaw = {
       type: 'evalRRaw',

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -266,6 +266,18 @@ function dispatch(msg: Message): void {
                       throwType();
                   }
                   break;
+                case 'boolean[]':
+                  switch (result.type()) {
+                    case 'logical':
+                      out = (result as RLogical).toArray();
+                      if (out.some((i) => i === null)) {
+                        throwType();
+                      }
+                      break;
+                    default:
+                      throwType();
+                  }
+                  break;
                 case 'number':
                   switch (result.type()) {
                     case 'logical':
@@ -282,10 +294,44 @@ function dispatch(msg: Message): void {
                       throwType();
                   }
                   break;
+                case 'number[]':
+                  switch (result.type()) {
+                    case 'logical':
+                      out = (result as RLogical).toArray();
+                      out = out.map((i) => i === null ? throwType() : Number(i));
+                      break;
+                    case 'integer':
+                      out = (result as RInteger).toArray();
+                      if (out.some((i) => i === null)) {
+                        throwType();
+                      }
+                      break;
+                    case 'double':
+                      out = (result as RDouble).toArray();
+                      if (out.some((i) => i === null)) {
+                        throwType();
+                      }
+                      break;
+                    default:
+                      throwType();
+                  }
+                  break;
                 case 'string':
                   switch (result.type()) {
                     case 'character':
                       out = (result as RCharacter).toString();
+                      break;
+                    default:
+                      throwType();
+                  }
+                  break;
+                case 'string[]':
+                  switch (result.type()) {
+                    case 'character':
+                      out = (result as RCharacter).toArray();
+                      if (out.some((i) => i === null)) {
+                        throwType();
+                      }
                       break;
                     default:
                       throwType();


### PR DESCRIPTION
I've stuck with the `evalRRaw` method name, rather than `evalRAs`, as it seems a little clearer when reading to my eyes.

* `evalRRaw` is made non-private and exposed on the `webR` class.
* Typing is updated to reflect return types based on `outputType` argument.
* Some additional argument possibilities and `switch` branches are added to handle returning JS arrays.
* Docs are updated to describe `evalRRaw`.