### PR TITLE
Mark some exports as internal, removing them from the final documentation

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'plugin:jsdoc/recommended',
     'google',
     './node_modules/gts',
     'plugin:jest/recommended',
@@ -20,7 +21,7 @@ module.exports = {
       project: ['./tsconfig.json'],
   },
   ignorePatterns: ['.eslintrc.js', 'pre.js', 'esbuild.js', 'jest.config.js'],
-  plugins: ['@typescript-eslint', 'jest'],
+  plugins: ['@typescript-eslint', 'jest', 'jsdoc'],
   rules: {
      "@typescript-eslint/no-explicit-any": "off",
      "@typescript-eslint/no-unsafe-member-access": "off",
@@ -32,7 +33,20 @@ module.exports = {
      "@typescript-eslint/no-implied-eval": "off",
      "@typescript-eslint/semi": ["error", "always"],
      "new-cap": ["error", { "capIsNewExceptions": ["UTF8ToString"] }],
-     "require-jsdoc": "off",
+     "require-jsdoc": "off", // Built-in jsdoc support is deprecated, use jsdoc plugin instead
+     "valid-jsdoc": "off",
+     "jsdoc/require-jsdoc": "off",
+     "jsdoc/newline-after-description": "off",
+     "jsdoc/no-multi-asterisks": ["error" | "warn", { "allowWhitespace": true }],
      'prettier/prettier': 0
+  },
+  settings: {
+    jsdoc: {
+      ignorePrivate: true,
+      ignoreInternal: true,
+      tagNamePreference: {
+        "typeParam": "typeParam",
+      }
+    }
   }
 };

--- a/src/console/console.ts
+++ b/src/console/console.ts
@@ -40,7 +40,8 @@ export interface ConsoleCallbacks {
 export class Console {
   /** The supporting instance of webR */
   webR: WebR;
-  /** A HTML canvas element
+  /**
+   * A HTML canvas element
    *
    * The canvas graphics device writes to this element by default. Undefined
    * when HTML canvas is unsupported.

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "src",
+  "name": "@r-wasm/webr",
+  "version": "0.1.0-alpha.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "@r-wasm/webr",
+      "version": "0.1.0-alpha.18",
+      "license": "SEE LICENSE IN LICENCE.md",
       "dependencies": {
         "@types/emscripten": "^1.39.6",
         "jquery": "^3.6.0",
@@ -26,6 +30,7 @@
         "eslint": "^8.33.0",
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-jest": "^26.8.7",
+        "eslint-plugin-jsdoc": "^40.0.1",
         "gts": "^3.1.0",
         "jest": "^28.1.3",
         "ts-jest": "^28.0.8",
@@ -649,6 +654,20 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
@@ -2250,6 +2269,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3015,6 +3043,27 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "40.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.0.1.tgz",
+      "integrity": "sha512-KkiRInury7YrjjV5aCHDxwsPy6XFt5p2b2CnpDMITnWs8patNPf5kj24+VXIWw45kP6z/B0GOKfrYczB56OjQQ==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.36.1",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.8",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-node": {
@@ -5081,6 +5130,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -7973,6 +8031,17 @@
         }
       }
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      }
+    },
     "@esbuild/linux-loong64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
@@ -9161,6 +9230,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -9632,6 +9707,21 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "40.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.0.1.tgz",
+      "integrity": "sha512-KkiRInury7YrjjV5aCHDxwsPy6XFt5p2b2CnpDMITnWs8patNPf5kj24+VXIWw45kP6z/B0GOKfrYczB56OjQQ==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.36.1",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.8",
+        "spdx-expression-parse": "^3.0.1"
       }
     },
     "eslint-plugin-node": {
@@ -11153,6 +11243,12 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true
     },
     "jsesc": {
       "version": "2.5.2",

--- a/src/package.json
+++ b/src/package.json
@@ -43,11 +43,21 @@
   },
   "typesVersions": {
     "*": {
-      "repl": ["dist/repl/repl"],
-      "repl/*": ["dist/repl/*"],
-      "console": ["dist/console/console"],
-      "console/*": ["dist/console/*"],
-      "*": ["dist/webR/*"]
+      "repl": [
+        "dist/repl/repl"
+      ],
+      "repl/*": [
+        "dist/repl/*"
+      ],
+      "console": [
+        "dist/console/console"
+      ],
+      "console/*": [
+        "dist/console/*"
+      ],
+      "*": [
+        "dist/webR/*"
+      ]
     }
   },
   "engines": {
@@ -57,10 +67,10 @@
     "@types/emscripten": "^1.39.6",
     "jquery": "^3.6.0",
     "jstree": "^3.3.12",
+    "xmlhttprequest-ssl": "^2.1.0",
     "xterm": "^5.1.0",
     "xterm-addon-fit": "^0.7.0",
-    "xterm-readline": "^1.1.1",
-    "xmlhttprequest-ssl": "^2.1.0"
+    "xterm-readline": "^1.1.1"
   },
   "devDependencies": {
     "@types/jest": "^28.1.8",
@@ -75,6 +85,7 @@
     "eslint": "^8.33.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-jest": "^26.8.7",
+    "eslint-plugin-jsdoc": "^40.0.1",
     "gts": "^3.1.0",
     "jest": "^28.1.3",
     "ts-jest": "^28.0.8",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -34,6 +34,7 @@
     "hideBreadcrumbs": true,
     "githubPages": false,
     "excludePrivate": true,
+    "excludeInternal": true,
   },
   "include": ["**/*.ts"],
 }

--- a/src/webR/chan/message.ts
+++ b/src/webR/chan/message.ts
@@ -28,6 +28,7 @@ export interface Response {
   };
 }
 
+/** @internal */
 export function newRequest(msg: Message, transferables?: [Transferable]): Request {
   return newRequestResponseMessage(
     {
@@ -41,6 +42,7 @@ export function newRequest(msg: Message, transferables?: [Transferable]): Reques
   );
 }
 
+/** @internal */
 export function newResponse(uuid: UUID, resp: unknown, transferables?: [Transferable]): Response {
   return newRequestResponseMessage(
     {
@@ -54,6 +56,7 @@ export function newResponse(uuid: UUID, resp: unknown, transferables?: [Transfer
   );
 }
 
+/** @internal */
 function newRequestResponseMessage<T>(msg: T, transferables?: [Transferable]): T {
   // Signal to Synclink that the data contains objects we wish to
   // transfer, as in `postMessage()`
@@ -63,7 +66,9 @@ function newRequestResponseMessage<T>(msg: T, transferables?: [Transferable]): T
   return msg;
 }
 
-/** A webR communication channel sync-request. */
+/** A webR communication channel sync-request.
+ * @internal
+ */
 export interface SyncRequest {
   type: 'sync-request';
   data: {
@@ -72,7 +77,8 @@ export interface SyncRequest {
   };
 }
 
-/** Transfer data required when using sync-request with SharedArrayBuffer. */
+/** Transfer data required when using sync-request with SharedArrayBuffer.
+ * @internal */
 export interface SyncRequestData {
   taskId?: number;
   sizeBuffer: Int32Array;
@@ -80,6 +86,7 @@ export interface SyncRequestData {
   dataBuffer: Uint8Array;
 }
 
+/** @internal */
 export function newSyncRequest(msg: Message, data: SyncRequestData): SyncRequest {
   return {
     type: 'sync-request',
@@ -94,6 +101,7 @@ const decoder = new TextDecoder('utf-8');
  * Encode data for transfering from worker thread to main thread.
  * @param {any} data The message data to be serialised and encoded.
  * @return {Uint8Array} The encoded data.
+ * @internal
  * */
 export function encodeData(data: any): Uint8Array {
   // TODO: Pass a `replacer` function
@@ -104,6 +112,7 @@ export function encodeData(data: any): Uint8Array {
  * Decode data that has been transferred from worker thread to main thread.
  * @param {any} data The message data to be decoded.
  * @return {unknown} The data after decoding.
+ * @internal
  * */
 export function decodeData(data: Uint8Array): unknown {
   return JSON.parse(decoder.decode(data)) as unknown;

--- a/src/webR/chan/task-worker.ts
+++ b/src/webR/chan/task-worker.ts
@@ -229,8 +229,7 @@ let handleInterrupt = (): void => {
 /**
  * Sets the interrupt handler. This is called when the computation is
  * interrupted. Should zero the interrupt buffer and throw an exception.
- * @function handler
- * @param {handler} handler
+ * @internal
  */
 export function setInterruptHandler(handler: () => void) {
   handleInterrupt = handler;
@@ -239,7 +238,7 @@ export function setInterruptHandler(handler: () => void) {
 /**
  * Sets the interrupt buffer. Should be a shared array buffer. When element 0
  * is set non-zero it signals an interrupt.
- * @param {ArrayBufferLike} buffer
+ * @internal
  */
 export function setInterruptBuffer(buffer: ArrayBufferLike) {
   interruptBuffer = new Int32Array(buffer);

--- a/src/webR/payload.ts
+++ b/src/webR/payload.ts
@@ -44,7 +44,7 @@ export function webRPayloadError(payload: WebRPayloadErr): Error {
  * Test for an WebRPayload instance.
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is an instance of an WebRPayload.
+ * @returns {boolean} True if the object is an instance of an WebRPayload.
  */
 export function isWebRPayload(value: any): value is WebRPayload {
   return value && typeof value === 'object' && 'payloadType' in value && 'obj' in value;
@@ -54,7 +54,7 @@ export function isWebRPayload(value: any): value is WebRPayload {
  * Test for an WebRPayloadPtr instance.
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is an instance of an WebRPayloadPtr.
+ * @returns {boolean} True if the object is an instance of an WebRPayloadPtr.
  */
 export function isWebRPayloadPtr(value: any): value is WebRPayloadPtr {
   return isWebRPayload(value) && value.payloadType === 'ptr';
@@ -64,7 +64,7 @@ export function isWebRPayloadPtr(value: any): value is WebRPayloadPtr {
  * Test for an WebRPayloadRaw instance.
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is an instance of an WebRPayloadRaw.
+ * @returns {boolean} True if the object is an instance of an WebRPayloadRaw.
  */
 export function isWebRPayloadRaw(value: any): value is WebRPayloadRaw {
   return isWebRPayload(value) && value.payloadType === 'raw';

--- a/src/webR/payload.ts
+++ b/src/webR/payload.ts
@@ -33,6 +33,7 @@ export type WebRPayloadErr = {
 export type WebRPayload = WebRPayloadRaw | WebRPayloadPtr;
 export type WebRPayloadWorker = WebRPayloadRaw | WebRPayloadPtr | WebRPayloadErr;
 
+/* @internal */
 export function webRPayloadError(payload: WebRPayloadErr): Error {
   const e = new Error(payload.obj.message);
   e.name = payload.obj.name;

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -117,6 +117,7 @@ function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RWorker.RObject>) 
  *
  * When the optional payload argument has not been provided, an
  * {@link RWorker.RObject} static method is called.
+ * @internal
  */
 export function targetMethod(chan: ChannelMain, prop: string): any;
 export function targetMethod(chan: ChannelMain, prop: string, payload: WebRPayloadPtr): any;

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -189,7 +189,7 @@ async function newRObject(
  *
  * @param {ChannelMain} chan The current main thread communication channel.
  * @param {WebRPayloadPtr} payload A webR payload referencing an R object.
- * @return {RProxy<RWorker.RObject>} An {@link RObject} corresponding to the
+ * @returns {RProxy<RWorker.RObject>} An {@link RObject} corresponding to the
  * referenced R object.
  */
 export function newRProxy(chan: ChannelMain, payload: WebRPayloadPtr): RProxy<RWorker.RObject> {
@@ -226,9 +226,8 @@ export function newRProxy(chan: ChannelMain, payload: WebRPayloadPtr): RProxy<RW
  * @param {ShelterID} shelter The shelter ID to protect returned objects with.
  * @param {(RType | 'object')} objType The R object type, or `'object'` for the
  * generic {@link RWorker.RObject} class.
- * @return {RWorker.RObject} A proxy to the R object class corresponding to the
+ * @returns {RWorker.RObject} A proxy to the R object class corresponding to the
  * given value of the `objType` argument.
- *
  * @typeParam T The type for the proxied class constructor argument.
  * @typeParam R The type to be returned from the proxied class constructor.
  */

--- a/src/webR/robj-main.ts
+++ b/src/webR/robj-main.ts
@@ -30,7 +30,7 @@ export type RFunction = RProxy<RWorker.RFunction> & ((...args: unknown[]) => Pro
  * RObject is the user facing interface to R objects.
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is an instance of an RObject.
+ * @returns {boolean} True if the object is an instance of an RObject.
  */
 export function isRObject(value: any): value is RObject {
   return (
@@ -45,7 +45,7 @@ export function isRObject(value: any): value is RObject {
  * Test for an RFunction instance
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is an instance of an RFunction.
+ * @returns {boolean} True if the object is an instance of an RFunction.
  */
 export function isRFunction(value: any): value is RFunction {
   return Boolean(isRObject(value) && value._payload.obj.methods?.includes('exec'));

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -101,7 +101,7 @@ export type WebRDataScalar<T> = T | RMain.RObject | RWorker.RObjectBase;
  * Test if an object is of type {@link Complex}.
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is of type {@link Complex}.
+ * @returns {boolean} True if the object is of type {@link Complex}.
  */
 export function isComplex(value: any): value is Complex {
   return value && typeof value === 'object' && 're' in value && 'im' in value;

--- a/src/webR/tree.ts
+++ b/src/webR/tree.ts
@@ -49,7 +49,7 @@ export type WebRDataTreeAtomic<T> = {
  * Test for a {@link WebRDataTree} instance
  *
  * @param {any} value The object to test.
- * @return {boolean} True if the object is an instance of a {@link WebRDataTree}.
+ * @returns {boolean} True if the object is an instance of a {@link WebRDataTree}.
  */
 export function isWebRDataTree(value: any): value is WebRDataTree {
   return value && typeof value === 'object' && Object.keys(RTypeMap).includes(value.type as string);

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -8,6 +8,7 @@ import { RType, WebRData } from './robj';
 
 export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';
 
+/** @internal */
 export interface CallRObjectMethodMessage extends Message {
   type: 'callRObjectMethod';
   data: {
@@ -54,6 +55,7 @@ export interface EvalROptions {
   withHandlers?: boolean;
 }
 
+/** @internal */
 export interface CaptureRMessage extends Message {
   type: 'captureR';
   data: {
@@ -63,6 +65,7 @@ export interface CaptureRMessage extends Message {
   };
 }
 
+/** @internal */
 export interface EvalRMessage extends Message {
   type: 'evalR';
   data: {
@@ -82,6 +85,7 @@ export type EvalRMessageOutputType =
   | 'string'
   | 'string[]';
 
+/** @internal */
 export interface EvalRMessageRaw extends Message {
   type: 'evalRRaw';
   data: {
@@ -91,11 +95,13 @@ export interface EvalRMessageRaw extends Message {
   };
 }
 
+/** @internal */
 export interface FSMessage extends Message {
   type: 'lookupPath' | 'mkdir' | 'rmdir' | 'unlink';
   data: { path: string };
 }
 
+/** @internal */
 export interface FSReadFileMessage extends Message {
   type: 'readFile';
   data: {
@@ -104,6 +110,7 @@ export interface FSReadFileMessage extends Message {
   };
 }
 
+/** @internal */
 export interface FSWriteFileMessage extends Message {
   type: 'writeFile';
   data: {
@@ -113,6 +120,7 @@ export interface FSWriteFileMessage extends Message {
   };
 }
 
+/** @internal */
 export interface NewRObjectMessage extends Message {
   type: 'newRObject';
   data: {
@@ -122,15 +130,18 @@ export interface NewRObjectMessage extends Message {
   };
 }
 
+/** @internal */
 export interface NewShelterMessage extends Message {
   type: 'newShelter';
 }
 
+/** @internal */
 export interface ShelterMessage extends Message {
   type: 'shelterPurge' | 'shelterSize';
   data: ShelterID;
 }
 
+/** @internal */
 export interface ShelterDestroyMessage extends Message {
   type: 'shelterDestroy';
   data: { id: ShelterID; obj: WebRPayloadPtr };

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -39,20 +39,20 @@ export interface WebRFS {
    * Lookup information about a file or directory node in the Emscripten
    * virtual file system.
    * @param {string} path Path to the requested node.
-   * @return {Promise<FSNode>} The requested node.
+   * @returns {Promise<FSNode>} The requested node.
    */
   lookupPath: (path: string) => Promise<FSNode>;
   /**
    * Create a directory on the Emscripten virtual file system.
    * @param {string} path Path of the directory to create.
-   * @return {Promise<FSNode>} The newly created directory node.
+   * @returns {Promise<FSNode>} The newly created directory node.
    */
   mkdir: (path: string) => Promise<FSNode>;
   /**
    * Get the content of a file on the Emscripten virtual file system.
    * @param {string} path Path of the file to read.
    * @param {string} [flags] Open the file with the specified flags.
-   * @return {Promise<Uint8Array>} The content of the requested file.
+   * @returns {Promise<Uint8Array>} The content of the requested file.
    */
   readFile: (path: string, flags?: string) => Promise<Uint8Array>;
   /**
@@ -88,43 +88,51 @@ export type FSNode = {
  * The configuration settings to be used when starting webR.
  */
 export interface WebROptions {
-  /** Command line arguments to be passed to R.
+  /**
+   * Command line arguments to be passed to R.
    * Default: `[]`.
    */
   RArgs?: string[];
 
-  /** Environment variables to be made available for the R process.
+  /**
+   * Environment variables to be made available for the R process.
    * Default: `{ R_HOME: '/usr/lib/R', R_ENABLE_JIT: 0 }`.
    */
   REnv?: { [key: string]: string };
 
-  /** The base URL used for downloading R WebAssembly binaries.
+  /**
+   * The base URL used for downloading R WebAssembly binaries.
    *  Default: `'https://webr.r-wasm.org/[version]/'`
    */
   WEBR_URL?: string;
 
-  /** The repo URL to use when downloading R WebAssembly packages.
+  /**
+   * The repo URL to use when downloading R WebAssembly packages.
    * Default: `'https://repo.r-wasm.org/`
    */
   PKG_URL?: string;
 
-  /** The base URL from where to load JavaScript worker scripts when loading
+  /**
+   * The base URL from where to load JavaScript worker scripts when loading
    * webR with the ServiceWorker communication channel mode.
    * Default: `''`
    */
   SW_URL?: string;
 
-  /** The WebAssembly user's home directory and initial working directory.
+  /**
+   * The WebAssembly user's home directory and initial working directory.
    * Default: `'/home/web_user'`
    */
   homedir?: string;
 
-  /** Start R in interactive mode?
+  /**
+   * Start R in interactive mode?
    * Default: `true`.
    */
   interactive?: boolean;
 
-  /** Set the communication channel type to be used.
+  /**
+   * Set the communication channel type to be used.
    * Deafult: `channelType.Automatic`
    */
   channelType?: (typeof ChannelType)[keyof typeof ChannelType];
@@ -191,7 +199,7 @@ export class WebR {
   }
 
   /**
-   * @return {Promise<void>} A promise that resolves once webR has been
+   * @returns {Promise<void>} A promise that resolves once webR has been
    * intialised.
    */
   async init() {
@@ -236,7 +244,7 @@ export class WebR {
 
   /**
    * Read from the communication channel and return an output message.
-   * @return {Promise<Message>}
+   * @returns {Promise<Message>} The output message
    */
   async read(): Promise<Message> {
     return await this.#chan.read();
@@ -245,7 +253,7 @@ export class WebR {
   /**
    * Flush the output queue in the communication channel and return all output
    * messages.
-   * @return {Promise<Message[]>}
+   * @returns {Promise<Message[]>} The output messages
    */
   async flush(): Promise<Message[]> {
     return await this.#chan.flush();
@@ -299,7 +307,7 @@ export class WebR {
    *
    * @param {string} code The R code to evaluate.
    * @param {EvalROptions} [options] Options for the execution environment.
-   * @return {Promise<RObject>} The result of the computation.
+   * @returns {Promise<RObject>} The result of the computation.
    */
   async evalR(code: string, options?: EvalROptions): Promise<RObject> {
     return this.globalShelter.evalR(code, options);
@@ -322,13 +330,13 @@ export class WebR {
   }
 
   /**
-    * Evaluate the given R code, returning the result as a raw JavaScript object.
-    *
-    * @param {string} code The R code to evaluate.
-    * @param {EvalRMessageOutputType} outputType JavaScript type to return the result as.
-    * @param {EvalROptions} [options] Options for the execution environment.
-    * @return {Promise<unknown>} The result of the computation.
-    */
+   * Evaluate the given R code, returning the result as a raw JavaScript object.
+   *
+   * @param {string} code The R code to evaluate.
+   * @param {EvalRMessageOutputType} outputType JavaScript type to return the result as.
+   * @param {EvalROptions} [options] Options for the execution environment.
+   * @returns {Promise<unknown>} The result of the computation.
+   */
   async evalRRaw(code: string, outputType: 'void', options?: EvalROptions): Promise<void>;
   async evalRRaw(code: string, outputType: 'boolean', options?: EvalROptions): Promise<boolean>;
   async evalRRaw(code: string, outputType: 'boolean[]', options?: EvalROptions): Promise<boolean[]>;
@@ -466,7 +474,7 @@ export class Shelter {
    *
    * @param {string} code The R code to evaluate.
    * @param {EvalROptions} [options] Options for the execution environment.
-   * @return {Promise<RObject>} The result of the computation.
+   * @returns {Promise<RObject>} The result of the computation.
    */
   async evalR(code: string, options: EvalROptions = {}): Promise<RObject> {
     const opts = replaceInObject(options, isRObject, (obj: RObject) => obj._payload);
@@ -493,7 +501,7 @@ export class Shelter {
    *
    * @param {string} code The R code to evaluate.
    * @param {EvalROptions} [options] Options for the execution environment.
-   * @return {Promise<{result: RObject, output: unknown[]}>} An object
+   * @returns {Promise<{result: RObject, output: unknown[]}>} An object
    * containing the result of the computation and and array of captured output.
    */
   async captureR(code: string, options: EvalROptions = {}): Promise<{

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -415,6 +415,7 @@ export class Shelter {
     this.#chan = chan;
   }
 
+  /* @internal */
   async init() {
     if (this.#initialised) {
       return;


### PR DESCRIPTION
Apparently the internal eslint typedoc support has been deprecated for a while [1]. In this PR it is disabled and instead we use the `eslint-plugin-jsdoc` plugin to deal with linting typedoc comments.

The first commit makes the above change and fixes up eslint warnings/errors.

The second commit marks a selection of exports as `@internal` [2]. The typedoc docs suggest using `@internal` rather than the `@private` and `@public` tags. There is also an `@experimental` [3] we might want to start using going forward.

[1] https://eslint.org/blog/2018/11/jsdoc-end-of-life/
[2] https://typedoc.org/tags/internal/
[3] https://typedoc.org/tags/experimental/